### PR TITLE
Do validation on execute

### DIFF
--- a/src/AutoLineJob.sol
+++ b/src/AutoLineJob.sol
@@ -104,7 +104,7 @@ contract AutoLineJob is IJob {
             ) continue;
 
             // Good to adjust!
-            return (true, abi.encodeWithSelector(AutoLineLike.exec.selector, ilk));
+            return (true, abi.encode(ilk));
         }
 
         return (false, bytes("No ilks ready"));

--- a/src/AutoLineJob.sol
+++ b/src/AutoLineJob.sol
@@ -57,7 +57,7 @@ contract AutoLineJob is IJob {
     }
 
     function execute(bytes32 network, bytes calldata execPayload) external override {
-        require(sequencer.isMaster(network));
+        require(sequencer.isMaster(network), "not-master");
         
         bytes32 ilk = abi.decode(execPayload, (bytes32));
 
@@ -68,9 +68,9 @@ contract AutoLineJob is IJob {
         // We need to be over the threshold amounts
         (uint256 maxLine, uint256 gap,,,) = autoline.ilks(ilk);
         if (newLine > line) {
-            require(newLine == maxLine || newLine >= line + gap * thi / BPS);
+            require(newLine == maxLine || newLine >= line + gap * thi / BPS, "threshold-upper");
         } else {
-            require(newLine + gap * tlo / BPS <= line);
+            require(newLine + gap * tlo / BPS <= line, "threshold-lower");
         }
     }
 

--- a/src/DssCron.t.sol
+++ b/src/DssCron.t.sol
@@ -521,7 +521,7 @@ contract DssCronTest is DSTest {
         verify_no_liquidation_job(NET_A, liquidatorJob);
 
         // This will put it just below market price -- should trigger with only the no profit one
-        hevm.warp(block.timestamp + 30 minutes);
+        hevm.warp(block.timestamp + 31 minutes);
 
         verify_no_liquidation_job(NET_A, liquidatorJob500);
         uint256 vowDai = vat.dai(vow);
@@ -549,7 +549,7 @@ contract DssCronTest is DSTest {
         verify_no_liquidation_job(NET_A, liquidatorJob500);
 
         // This will put it just below market price -- should still not trigger
-        hevm.warp(block.timestamp + 30 minutes);
+        hevm.warp(block.timestamp + 31 minutes);
         verify_no_liquidation_job(NET_A, liquidatorJob500);
 
         // A little bit further

--- a/src/DssCron.t.sol
+++ b/src/DssCron.t.sol
@@ -294,14 +294,13 @@ contract DssCronTest is DSTest {
 
     function clear_other_ilks(bytes32 network) internal {
         while(true) {
-            (bool canExec, address target, bytes memory execPayload) = autoLineJob.getNextJob(network);
-            if (!canExec) break;
-            bytes32 ilk = abi.decode(execPayload, (bytes32));
+            (bool canWork, bytes memory args) = autoLineJob.workable(network);
+            if (!canWork) break;
+            bytes32 ilk = abi.decode(args, (bytes32));
             if (ilk == ILK) break;
             (,,, uint256 line,) = vat.ilks(ilk);
-            (bool success, bytes memory result) = target.call(execPayload);
-            uint256 newLine = abi.decode(result, (uint256));
-            assertTrue(success, "Execution should have succeeded.");
+            autoLineJob.work(network, args);
+            (,,, uint256 newLine,) = vat.ilks(ilk);
             assertTrue(line != newLine, "Line should have changed.");
         }
     }
@@ -338,27 +337,24 @@ contract DssCronTest is DSTest {
     }
 
     function trigger_next_autoline_job(bytes32 network, bytes32 ilk) internal {
-        (bool canExec, address target, bytes memory execPayload) = autoLineJob.getNextJob(network);
-        assertTrue(canExec, "Expecting to be able to execute.");
-        assertEq(target, address(autoline));
-        bytes memory expectedPayload = abi.encodeWithSelector(AutoLineLike.exec.selector, ilk);
-        for (uint256 i = 0; i < expectedPayload.length; i++) {
-            assertEq(execPayload[i], expectedPayload[i]);
+        (bool canWork, bytes memory args) = autoLineJob.workable(network);
+        assertTrue(canWork, "Expecting to be able to execute.");
+        bytes memory expectedArgs = abi.encode(ilk);
+        for (uint256 i = 0; i < expectedArgs.length; i++) {
+            assertEq(args[i], expectedArgs[i]);
         }
         (,,, uint256 line,) = vat.ilks(ilk);
-        (bool success, bytes memory result) = target.call(execPayload);
-        uint256 newLine = abi.decode(result, (uint256));
-        assertTrue(success, "Execution should have succeeded.");
+        autoLineJob.work(network, args);
+        (,,, uint256 newLine,) = vat.ilks(ilk);
         assertTrue(line != newLine, "Line should have changed.");
     }
 
     function verify_no_autoline_job(bytes32 network) internal {
-        (bool canExec, address target, bytes memory execPayload) = autoLineJob.getNextJob(network);
-        assertTrue(!canExec, "Expecting NOT to be able to execute.");
-        assertEq(target, address(0));
-        bytes memory expectedPayload = "No ilks ready";
-        for (uint256 i = 0; i < expectedPayload.length; i++) {
-            assertEq(execPayload[i], expectedPayload[i]);
+        (bool canWork, bytes memory args) = autoLineJob.workable(network);
+        assertTrue(!canWork, "Expecting NOT to be able to execute.");
+        bytes memory expectedArgs = "No ilks ready";
+        for (uint256 i = 0; i < expectedArgs.length; i++) {
+            assertEq(args[i], expectedArgs[i]);
         }
     }
 
@@ -494,21 +490,19 @@ contract DssCronTest is DSTest {
     }
 
     function trigger_next_liquidation_job(bytes32 network, LiquidatorJob liquidator) internal {
-        (bool canExec, address target, bytes memory execPayload) = liquidator.getNextJob(network);
-        assertTrue(canExec, "Expecting to be able to execute.");
-        assertEq(target, address(liquidator));
+        (bool canWork, bytes memory args) = liquidator.workable(network);
+        assertTrue(canWork, "Expecting to be able to execute.");
         // No need to actually execute as the detection of a successful job will execute
-        //(bool success,) = target.call(execPayload);
+        //(bool success,) = target.call(args);
         //assertTrue(success, "Execution should have succeeded.");
     }
 
     function verify_no_liquidation_job(bytes32 network, LiquidatorJob liquidator) internal {
-        (bool canExec, address target, bytes memory execPayload) = liquidator.getNextJob(network);
-        assertTrue(!canExec, "Expecting NOT to be able to execute.");
-        assertEq(target, address(0));
-        bytes memory expectedPayload = "No auctions";
-        for (uint256 i = 0; i < expectedPayload.length; i++) {
-            assertEq(execPayload[i], expectedPayload[i]);
+        (bool canWork, bytes memory args) = liquidator.workable(network);
+        assertTrue(!canWork, "Expecting NOT to be able to execute.");
+        bytes memory expectedArgs = "No auctions";
+        for (uint256 i = 0; i < expectedArgs.length; i++) {
+            assertEq(args[i], expectedArgs[i]);
         }
     }
 

--- a/src/IJob.sol
+++ b/src/IJob.sol
@@ -16,5 +16,6 @@
 pragma solidity ^0.8.9;
 
 interface IJob {
-    function getNextJob(bytes32 operator) external returns (bool canExec, address target, bytes memory execPayload);
+    function execute(bytes32 operator, bytes calldata execPayload) external;
+    function getNextJob(bytes32 operator) external returns (bool canExec, bytes memory execPayload);
 }

--- a/src/IJob.sol
+++ b/src/IJob.sol
@@ -16,6 +16,6 @@
 pragma solidity ^0.8.9;
 
 interface IJob {
-    function execute(bytes32 operator, bytes calldata execPayload) external;
-    function getNextJob(bytes32 operator) external returns (bool canExec, bytes memory execPayload);
+    function work(bytes32 network, bytes calldata args) external;
+    function workable(bytes32 network) external returns (bool canWork, bytes memory args);
 }

--- a/src/LiquidatorJob.sol
+++ b/src/LiquidatorJob.sol
@@ -131,8 +131,7 @@ contract LiquidatorJob is IJob {
         bytes32[] memory ilks = ilkRegistry.list();
         for (uint256 i = 0; i < ilks.length; i++) {
             bytes32 ilk = ilks[i];
-            (,, uint256 class,, address gem,, address join, address clip) = ilkRegistry.info(ilk);
-            if (class != 1) continue;
+            (,,,, address gem,, address join, address clip) = ilkRegistry.info(ilk);
             if (clip == address(0)) continue;
             
             uint256[] memory auctions = ClipLike(clip).list();

--- a/src/LiquidatorJob.sol
+++ b/src/LiquidatorJob.sol
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "./IJob.sol";
 
@@ -26,6 +26,7 @@ interface VatLike {
     function hope(address) external;
     function dai(address) external view returns (uint256);
     function move(address, address, uint256) external;
+    function wards(address) external view returns (uint256);
 }
 
 interface DaiJoinLike {
@@ -66,10 +67,6 @@ interface ClipLike {
     function sales(uint256) external view returns (uint256,uint256,uint256,address,uint96,uint256);
 }
 
-interface ILiquidatorJob {
-    function execute(address target, bytes calldata data) external;
-}
-
 // Provide backstop liquidations across all supported DEXs
 contract LiquidatorJob is IJob {
 
@@ -86,6 +83,10 @@ contract LiquidatorJob is IJob {
     address public immutable uniswapV3Callee;
     uint256 public immutable minProfitBPS;          // Profit as % of debt owed
 
+    // --- Errors ---
+    error NotMaster(bytes32 network);
+    error InvalidClipper(bytes32 network, address clip);
+
     constructor(address _sequencer, address _daiJoin, address _ilkRegistry, address _profitTarget, address _uniswapV3Callee, uint256 _minProfitBPS) {
         sequencer = SequencerLike(_sequencer);
         daiJoin = DaiJoinLike(_daiJoin);
@@ -99,21 +100,33 @@ contract LiquidatorJob is IJob {
         dai.approve(_daiJoin, type(uint256).max);
     }
 
-    // Warning! This contract can execute arbitrary code. Never give authorizations to anything.
-    function execute(address target, bytes calldata data) public {
-        if (vat.can(address(this), target) != 1) {
-            vat.hope(target);
+    function work(bytes32 network, bytes calldata args) public {
+        if (!sequencer.isMaster(network)) revert NotMaster(network);
+        
+        (address clip, uint256 auction, bytes memory calleePayload) = abi.decode(args, (address, uint256, bytes));
+        
+        // Verify clipper is a valid contract
+        // Easiest way to do this is check it's authed on the vat
+        if (vat.wards(clip) != 1) revert InvalidClipper(network, clip);
+
+        if (vat.can(address(this), clip) != 1) {
+            vat.hope(clip);
         }
-        (bool success,) = target.call(data);
-        require(success, "call failed");
+        ClipLike(clip).take(
+            auction,
+            type(uint256).max,
+            type(uint256).max,
+            uniswapV3Callee,
+            calleePayload
+        );
 
         // Dump all extra DAI into the profit target
         daiJoin.join(address(this), dai.balanceOf(address(this)));
         vat.move(address(this), profitTarget, vat.dai(address(this)));
     }
 
-    function getNextJob(bytes32 network) external override returns (bool, address, bytes memory) {
-        if (!sequencer.isMaster(network)) return (false, address(0), bytes("Network is not master"));
+    function workable(bytes32 network) external override returns (bool, bytes memory) {
+        if (!sequencer.isMaster(network)) return (false, bytes("Network is not master"));
         
         bytes32[] memory ilks = ilkRegistry.list();
         for (uint256 i = 0; i < ilks.length; i++) {
@@ -129,34 +142,27 @@ contract LiquidatorJob is IJob {
                 // Attempt to run this through Uniswap V3 liquidator
                 uint24[2] memory fees = [uint24(500), uint24(3000)];
                 for (uint256 p = 0; p < fees.length; p++) {
-                    bytes memory data;
+                    bytes memory args;
                     {
                         // Stack too deep
                         (, uint256 tab,,,,) = ClipLike(clip).sales(auction);
-                        bytes memory exchangeCalleeData = abi.encode(
+                        bytes memory calleePayload = abi.encode(
                             address(this),
                             join,
                             tab * minProfitBPS / BPS / RAY,
                             abi.encodePacked(gem, fees[p], dai),
                             address(0)
                         );
-                        data = abi.encodeWithSelector(
-                            ClipLike.take.selector,
+                        args = abi.encode(
+                            clip,
                             auction,
-                            type(uint256).max,
-                            type(uint256).max,
-                            uniswapV3Callee,
-                            exchangeCalleeData
+                            calleePayload
                         );
                     }
 
-                    try this.execute(clip, data) {
+                    try this.work(network, args) {
                         // Found an auction!
-                        return (true, address(this), abi.encodeWithSelector(
-                            ILiquidatorJob.execute.selector,
-                            clip,
-                            data
-                        ));
+                        return (true, args);
                     } catch {
                         // No valid auction -- carry on
                     }
@@ -164,7 +170,7 @@ contract LiquidatorJob is IJob {
             }
         }
 
-        return (false, address(0), bytes("No auctions"));
+        return (false, bytes("No auctions"));
     }
 
 }

--- a/src/Sequencer.sol
+++ b/src/Sequencer.sol
@@ -83,7 +83,7 @@ contract Sequencer {
     }
 
     // --- Views ---
-    function isMaster(bytes32 network) external view returns (bool) {
+    function isMaster(bytes32 network) public view returns (bool) {
         if (activeNetworks.length == 0) return false;
 
         return network == activeNetworks[(block.number / window) % activeNetworks.length];

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ set -e
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive" ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1; }
 
 if [[ -z "$1" ]]; then
-  forge test --rpc-url="$ETH_RPC_URL" --optimize --verbosity 1 --force
+  forge test --rpc-url="$ETH_RPC_URL" --optimize --force
 else
-  forge test --rpc-url="$ETH_RPC_URL" --optimize --match "$1" --verbosity 3 --force
+  forge test --rpc-url="$ETH_RPC_URL" --optimize --match "$1" -vvv --force
 fi


### PR DESCRIPTION
Instead of returning completely arbitrary contract calls, this will restrict to calling `execute(...)` on the same contract which will then perform any additional validation. This is needed for keeper networks to track where keepers have made a valid (non-reverting) call so that they can pay out accordingly.