### PR TITLE
Add active jobs tracking in the sequencer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 
 Keeper jobs for Maker protocol. Designed to support multiple Keeper Networks. All jobs will be deployed contracts which implement the `IJob` interface.
 
-Keeper Networks will be required to register instances of these `IJob` contracts and call `getNextJob(networkName)` to get the next available action to execute (if any). Funding of keeper networks is a separate task.
+Keeper Networks will be required to watch the `activeJobs` array in the `Sequencer` and find all instances of available jobs. Helper methods `getNextJobs(...)` can be used to check a subsection (or everything) of the array all at once. Each job is safe to be executed in parallel.
 
-# Deployed Contracts
+Funding of keeper networks is a separate task.
+
+# New Deployed Contracts (TBA)
+
+Sequencer: N/A  
+AutoLineJob: N/A  
+
+# Old Deployed Contracts
 
 Sequencer: [0xa0391743B97AaF8ce2662CeC316902D76c710dD3](https://etherscan.io/address/0xa0391743b97aaf8ce2662cec316902d76c710dd3#code)  
 AutoLineJob: [0xd3E01B079f0a787Fc2143a43E2Bdd799b2f34d9a](https://etherscan.io/address/0xd3E01B079f0a787Fc2143a43E2Bdd799b2f34d9a#code)  

--- a/src/DssCron.t.sol
+++ b/src/DssCron.t.sol
@@ -219,7 +219,7 @@ contract DssCronTest is DSTest {
 
         assertEq(sequencer.activeNetworks(0), NET_A);
         assertTrue(sequencer.networks(NET_A));
-        assertEq(sequencer.count(), 1);
+        assertEq(sequencer.numNetworks(), 1);
     }
 
     function testFail_sequencer_add_dupe_network() public {
@@ -232,7 +232,7 @@ contract DssCronTest is DSTest {
         sequencer.removeNetwork(0);
 
         assertTrue(!sequencer.networks(NET_A));
-        assertEq(sequencer.count(), 0);
+        assertEq(sequencer.numNetworks(), 0);
     }
 
     function test_sequencer_add_remove_networks() public {
@@ -240,7 +240,7 @@ contract DssCronTest is DSTest {
         sequencer.addNetwork(NET_B);
         sequencer.addNetwork(NET_C);
 
-        assertEq(sequencer.count(), 3);
+        assertEq(sequencer.numNetworks(), 3);
         assertEq(sequencer.activeNetworks(0), NET_A);
         assertEq(sequencer.activeNetworks(1), NET_B);
         assertEq(sequencer.activeNetworks(2), NET_C);
@@ -249,7 +249,7 @@ contract DssCronTest is DSTest {
         sequencer.removeNetwork(0);
 
 
-        assertEq(sequencer.count(), 2);
+        assertEq(sequencer.numNetworks(), 2);
         assertEq(sequencer.activeNetworks(0), NET_C);
         assertEq(sequencer.activeNetworks(1), NET_B);
     }
@@ -262,9 +262,9 @@ contract DssCronTest is DSTest {
         bytes32[3] memory networks = [NET_A, NET_B, NET_C];
 
         for (uint256 i = 0; i < sequencer.window() * 10; i++) {
-            assertTrue(sequencer.isMaster(networks[0]) == ((block.number / sequencer.window()) % sequencer.count() == 0));
-            assertTrue(sequencer.isMaster(networks[1]) == ((block.number / sequencer.window()) % sequencer.count() == 1));
-            assertTrue(sequencer.isMaster(networks[2]) == ((block.number / sequencer.window()) % sequencer.count() == 2));
+            assertTrue(sequencer.isMaster(networks[0]) == ((block.number / sequencer.window()) % sequencer.numNetworks() == 0));
+            assertTrue(sequencer.isMaster(networks[1]) == ((block.number / sequencer.window()) % sequencer.numNetworks() == 1));
+            assertTrue(sequencer.isMaster(networks[2]) == ((block.number / sequencer.window()) % sequencer.numNetworks() == 2));
             assertEq(
                 (sequencer.isMaster(networks[0]) ? 1 : 0) +
                 (sequencer.isMaster(networks[1]) ? 1 : 0) +

--- a/src/DssCron.t.sol
+++ b/src/DssCron.t.sol
@@ -248,9 +248,26 @@ contract DssCronTest is DSTest {
         // Should move NET_C (last element) to slot 0
         sequencer.removeNetwork(0);
 
-
         assertEq(sequencer.numNetworks(), 2);
         assertEq(sequencer.activeNetworks(0), NET_C);
+        assertEq(sequencer.activeNetworks(1), NET_B);
+    }
+
+    function test_sequencer_add_remove_networks_last() public {
+        sequencer.addNetwork(NET_A);
+        sequencer.addNetwork(NET_B);
+        sequencer.addNetwork(NET_C);
+
+        assertEq(sequencer.numNetworks(), 3);
+        assertEq(sequencer.activeNetworks(0), NET_A);
+        assertEq(sequencer.activeNetworks(1), NET_B);
+        assertEq(sequencer.activeNetworks(2), NET_C);
+
+        // Should remove the last element and not re-arrange
+        sequencer.removeNetwork(2);
+
+        assertEq(sequencer.numNetworks(), 2);
+        assertEq(sequencer.activeNetworks(0), NET_A);
         assertEq(sequencer.activeNetworks(1), NET_B);
     }
 
@@ -273,6 +290,63 @@ contract DssCronTest is DSTest {
 
             hevm.roll(block.number + 1);
         }
+    }
+
+    function test_sequencer_add_job() public {
+        sequencer.addJob(address(autoLineJob));
+
+        assertEq(sequencer.activeJobs(0), address(autoLineJob));
+        assertTrue(sequencer.jobs(address(autoLineJob)));
+        assertEq(sequencer.numJobs(), 1);
+    }
+
+    function testFail_sequencer_add_dupe_job() public {
+        sequencer.addJob(address(autoLineJob));
+        sequencer.addJob(address(autoLineJob));
+    }
+
+    function test_sequencer_add_remove_job() public {
+        sequencer.addJob(address(autoLineJob));
+        sequencer.removeJob(0);
+
+        assertTrue(!sequencer.jobs(address(autoLineJob)));
+        assertEq(sequencer.numJobs(), 0);
+    }
+
+    function test_sequencer_add_remove_jobs() public {
+        sequencer.addJob(address(autoLineJob));
+        sequencer.addJob(address(liquidatorJob));
+        sequencer.addJob(address(liquidatorJob500));
+
+        assertEq(sequencer.numJobs(), 3);
+        assertEq(sequencer.activeJobs(0), address(autoLineJob));
+        assertEq(sequencer.activeJobs(1), address(liquidatorJob));
+        assertEq(sequencer.activeJobs(2), address(liquidatorJob500));
+
+        // Should move liquidatorJob500 (last element) to slot 0
+        sequencer.removeJob(0);
+
+        assertEq(sequencer.numJobs(), 2);
+        assertEq(sequencer.activeJobs(0), address(liquidatorJob500));
+        assertEq(sequencer.activeJobs(1), address(liquidatorJob));
+    }
+
+    function test_sequencer_add_remove_jobs_last() public {
+        sequencer.addJob(address(autoLineJob));
+        sequencer.addJob(address(liquidatorJob));
+        sequencer.addJob(address(liquidatorJob500));
+
+        assertEq(sequencer.numJobs(), 3);
+        assertEq(sequencer.activeJobs(0), address(autoLineJob));
+        assertEq(sequencer.activeJobs(1), address(liquidatorJob));
+        assertEq(sequencer.activeJobs(2), address(liquidatorJob500));
+
+        // Should remove the last element and not re-arrange anything
+        sequencer.removeJob(2);
+
+        assertEq(sequencer.numJobs(), 2);
+        assertEq(sequencer.activeJobs(0), address(autoLineJob));
+        assertEq(sequencer.activeJobs(1), address(liquidatorJob));
     }
 
     // --- AutoLineJob tests ---

--- a/src/DssCron.t.sol
+++ b/src/DssCron.t.sol
@@ -25,6 +25,7 @@ interface Hevm {
     function roll(uint256) external;
     function store(address,bytes32,bytes32) external;
     function load(address,bytes32) external view returns (bytes32);
+    function expectRevert(bytes calldata) external;
 }
 
 interface AuthLike {
@@ -222,8 +223,9 @@ contract DssCronTest is DSTest {
         assertEq(sequencer.numNetworks(), 1);
     }
 
-    function testFail_sequencer_add_dupe_network() public {
+    function test_sequencer_add_dupe_network() public {
         sequencer.addNetwork(NET_A);
+        hevm.expectRevert(abi.encodeWithSignature("NetworkExists(bytes32)", NET_A));
         sequencer.addNetwork(NET_A);
     }
 
@@ -300,8 +302,9 @@ contract DssCronTest is DSTest {
         assertEq(sequencer.numJobs(), 1);
     }
 
-    function testFail_sequencer_add_dupe_job() public {
+    function test_sequencer_add_dupe_job() public {
         sequencer.addJob(address(autoLineJob));
+        hevm.expectRevert(abi.encodeWithSignature("JobExists(address)", autoLineJob));
         sequencer.addJob(address(autoLineJob));
     }
 

--- a/src/Sequencer.sol
+++ b/src/Sequencer.sol
@@ -116,7 +116,7 @@ contract Sequencer {
         emit AddJob(job);
     }
     function removeJob(uint256 index) external auth {
-        if (index >= activeNetworks.length) revert IndexTooHigh(index);
+        if (index >= activeJobs.length) revert IndexTooHigh(index);
 
         address job = activeJobs[index];
         if (index != activeJobs.length - 1) {

--- a/src/Sequencer.sol
+++ b/src/Sequencer.sol
@@ -15,10 +15,20 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity 0.8.9;
 
+interface JobLike {
+    function workable(bytes32 network) external returns (bool canWork, bytes memory args);
+}
+
 // Coordination between Keeper Networks
 // Only one should be active at a time
 // Use the block number to switch between networks
 contract Sequencer {
+
+    struct WorkableJob {
+        address job;
+        bool canWork;
+        bytes args;
+    }
 
     // --- Auth ---
     mapping (address => uint256) public wards;
@@ -39,6 +49,10 @@ contract Sequencer {
 
     mapping (bytes32 => bool) public networks;
     bytes32[] public activeNetworks;
+
+    mapping (address => bool) public jobs;
+    address[] public activeJobs;
+
     uint256 public window;
 
     // --- Events ---
@@ -47,6 +61,14 @@ contract Sequencer {
     event File(bytes32 indexed what, uint256 data);
     event AddNetwork(bytes32 indexed network);
     event RemoveNetwork(bytes32 indexed network);
+    event AddJob(address indexed job);
+    event RemoveJob(address indexed job);
+
+    // --- Errors ---
+    error InvalidFileParam(bytes32 what);
+    error NetworkExists(bytes32 network);
+    error JobExists(address job);
+    error IndexTooHigh(uint256 index);
 
     constructor () {
         wards[msg.sender] = 1;
@@ -57,12 +79,14 @@ contract Sequencer {
     function file(bytes32 what, uint256 data) external auth {
         if (what == "window") {
             window = data;
-        } else revert("Sequencer/file-unrecognized-param");
+        } else revert InvalidFileParam(what);
 
         emit File(what, data);
     }
+
+    // --- Network Admin ---
     function addNetwork(bytes32 network) external auth {
-        require(!networks[network], "Sequencer/network-exists");
+        if (networks[network]) revert NetworkExists(network);
 
         activeNetworks.push(network);
         networks[network] = true;
@@ -70,7 +94,7 @@ contract Sequencer {
         emit AddNetwork(network);
     }
     function removeNetwork(uint256 index) external auth {
-        require(index < activeNetworks.length, "Sequencer/index-too-high");
+        if (index >= activeNetworks.length) revert IndexTooHigh(index);
 
         bytes32 network = activeNetworks[index];
         if (index != activeNetworks.length - 1) {
@@ -82,17 +106,61 @@ contract Sequencer {
         emit RemoveNetwork(network);
     }
 
+    // --- Job Admin ---
+    function addJob(address job) external auth {
+        if (jobs[job]) revert JobExists(job);
+
+        activeJobs.push(job);
+        jobs[job] = true;
+
+        emit AddJob(job);
+    }
+    function removeJob(uint256 index) external auth {
+        if (index >= activeNetworks.length) revert IndexTooHigh(index);
+
+        address job = activeJobs[index];
+        if (index != activeJobs.length - 1) {
+            activeJobs[index] = activeJobs[activeJobs.length - 1];
+        }
+        activeJobs.pop();
+        jobs[job] = false;
+
+        emit RemoveJob(job);
+    }
+
     // --- Views ---
     function isMaster(bytes32 network) public view returns (bool) {
         if (activeNetworks.length == 0) return false;
 
         return network == activeNetworks[(block.number / window) % activeNetworks.length];
     }
-    function count() external view returns (uint256) {
+
+    function numNetworks() external view returns (uint256) {
         return activeNetworks.length;
     }
-    function list() external view returns (bytes32[] memory) {
+    function listAllNetworks() external view returns (bytes32[] memory) {
         return activeNetworks;
+    }
+
+    function numJobs() external view returns (uint256) {
+        return activeJobs.length;
+    }
+    function listAllJobs() external view returns (address[] memory) {
+        return activeJobs;
+    }
+
+    // --- Job helper functions ---
+    function getNextJobs(bytes32 network, uint256 startIndex, uint256 endIndexExcl) public returns (WorkableJob[] memory) {
+        WorkableJob[] memory _jobs = new WorkableJob[](endIndexExcl - startIndex);
+        for (uint256 i = startIndex; i < endIndexExcl; i++) {
+            JobLike job = JobLike(activeJobs[i]);
+            (bool canWork, bytes memory args) = job.workable(network);
+            _jobs[i - startIndex] = WorkableJob(address(job), canWork, args);
+        }
+        return _jobs;
+    }
+    function getNextJobs(bytes32 network) external returns (WorkableJob[] memory) {
+        return this.getNextJobs(network, 0, activeJobs.length);
     }
 
 }


### PR DESCRIPTION
Will allow keepers to dynamically track the active jobs instead of having to coordinate each time a new job is added. There is a check all jobs convenience function, but this will not scale forever so eventually bulk jobs will need to be broken up into sub-sections of the array.