### PR TITLE
Standardize the payments process

### DIFF
--- a/src/INetworkTreasury.sol
+++ b/src/INetworkTreasury.sol
@@ -18,7 +18,7 @@ pragma solidity 0.8.13;
 interface INetworkTreasury {
 
 	/**
-	 * This should return an estimate of the total value of the buffer in DAI.
+	 * @dev This should return an estimate of the total value of the buffer in DAI.
 	 * Keeper Networks should convert non-DAI assets to DAI value via an oracle.
 	 * 
 	 * Ex) If the network bulk trades DAI for ETH then the value of the ETH sitting

--- a/src/INetworkTreasury.sol
+++ b/src/INetworkTreasury.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity 0.8.13;
+
+interface INetworkTreasury {
+
+	/**
+	 * This should return an estimate of the total value of the buffer in DAI.
+	 * Keeper Networks should convert non-DAI assets to DAI value via an oracle.
+	 * 
+	 * Ex) If the network bulk trades DAI for ETH then the value of the ETH sitting
+	 * in the treasury should count towards this buffer size.
+	 */
+	function getBufferSize() external view returns (uint256);
+
+}

--- a/src/NetworkPaymentAdapter.sol
+++ b/src/NetworkPaymentAdapter.sol
@@ -109,7 +109,7 @@ contract NetworkPaymentAdapter {
         uint256 _bufferMax = bufferMax;
         uint256 _minimumPayment = minimumPayment;
 
-        if (bufferSize >= _bufferMax) revert BufferFull(bufferSize, _bufferMax);
+        if (bufferSize + _minimumPayment >= _bufferMax) revert BufferFull(bufferSize, _bufferMax);
         else if (pendingDai >= _minimumPayment) {
             vest.vest(vestId);
             

--- a/src/NetworkPaymentAdapter.sol
+++ b/src/NetworkPaymentAdapter.sol
@@ -76,6 +76,7 @@ contract NetworkPaymentAdapter {
 
     // --- Errors ---
     error InvalidFileParam(bytes32 what);
+    error UnauthorizedSender(address sender);
     error BufferFull(uint256 bufferSize, uint256 bufferMax);
     error PendingDaiTooSmall(uint256 pendingDai, uint256 minimumPayment);
 
@@ -104,6 +105,8 @@ contract NetworkPaymentAdapter {
 
     // --- Pay the keeper treasury ---
     function topUp() external returns (uint256 daiSent) {
+        if (msg.sender != address(treasury)) revert UnauthorizedSender(msg.sender);
+
         uint256 bufferSize = treasury.getBufferSize();
         uint256 pendingDai = vest.unpaid(vestId);
         uint256 _bufferMax = bufferMax;

--- a/src/NetworkPaymentAdapter.sol
+++ b/src/NetworkPaymentAdapter.sol
@@ -78,7 +78,7 @@ contract NetworkPaymentAdapter {
     // --- Errors ---
     error InvalidFileParam(bytes32 what);
     error UnauthorizedSender(address sender);
-    error BufferFull(uint256 bufferSize, uint256 bufferMax);
+    error BufferFull(uint256 bufferSize, uint256 minimumPayment, uint256 bufferMax);
     error PendingDaiTooSmall(uint256 pendingDai, uint256 minimumPayment);
 
     constructor(address _vest, uint256 _vestId, address _treasury, address _daiJoin, address _vow) {
@@ -118,7 +118,7 @@ contract NetworkPaymentAdapter {
         uint256 _bufferMax = bufferMax;
         uint256 _minimumPayment = minimumPayment;
 
-        if (bufferSize + _minimumPayment >= _bufferMax) revert BufferFull(bufferSize, _bufferMax);
+        if (bufferSize + _minimumPayment > _bufferMax) revert BufferFull(bufferSize, _minimumPayment, _bufferMax);
         else if (pendingDai >= _minimumPayment) {
             vest.vest(vestId);
             

--- a/src/NetworkPaymentAdapter.sol
+++ b/src/NetworkPaymentAdapter.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity 0.8.13;
+
+import {INetworkTreasury} from "./INetworkTreasury.sol";
+
+interface VestLike {
+    function vest(uint256) external;
+    function unpaid(uint256) external view returns (uint256);
+}
+
+interface DaiJoinLike {
+    function dai() external view returns (address);
+    function join(address, uint256) external;
+}
+
+interface DaiLike {
+    function balanceOf(address) external view returns (uint256);
+    function transfer(address, uint256) external returns (bool);
+}
+
+/// @title Payment adapter to the keeper network treasury
+/// @dev Sits between dss-vest and the keeper network treasury contract
+contract NetworkPaymentAdapter {
+
+    // --- Auth ---
+    mapping (address => uint256) public wards;
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+
+        emit Rely(usr);
+    }
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+
+        emit Deny(usr);
+    }
+    modifier auth {
+        require(wards[msg.sender] == 1, "Sequencer/not-authorized");
+        _;
+    }
+
+    // --- Data ---
+    VestLike public immutable vest;
+    uint256 public immutable vestId;
+    INetworkTreasury public immutable treasury;
+    DaiJoinLike public immutable daiJoin;
+    DaiLike public immutable dai;
+    address public immutable vow;
+
+    // --- Parameters ---
+    uint256 public bufferMax;
+    uint256 public minimumPayment;
+
+    // --- Tracking ---
+    uint256 public totalSent;
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+    event File(bytes32 indexed what, uint256 data);
+    event TopUp(uint256 bufferSize, uint256 daiBalance, uint256 daiSent, uint256 totalSent);
+
+    // --- Errors ---
+    error InvalidFileParam(bytes32 what);
+    error BufferFull(uint256 bufferSize, uint256 bufferMax);
+    error PendingDaiTooSmall(uint256 pendingDai, uint256 minimumPayment);
+
+    constructor(address _vest, uint256 _vestId, address _treasury, address _daiJoin, address _vow) {
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+
+        vest = VestLike(_vest);
+        vestId = _vestId;
+        treasury = INetworkTreasury(_treasury);
+        daiJoin = DaiJoinLike(_daiJoin);
+        dai = DaiLike(daiJoin.dai());
+        vow = _vow;
+    }
+
+    // --- Administration ---
+    function file(bytes32 what, uint256 data) external auth {
+        if (what == "bufferMax") {
+            bufferMax = data;
+        } else if (what == "minimumPayment") {
+            minimumPayment = data;
+        } else revert InvalidFileParam(what);
+
+        emit File(what, data);
+    }
+
+    // --- Pay the keeper treasury ---
+    function topUp() external returns (uint256 daiSent) {
+        uint256 pendingDai = vest.unpaid(vestId);
+        uint256 bufferSize = treasury.getBufferSize();
+        uint256 _bufferMax = bufferMax;
+        uint256 _minimumPayment = minimumPayment;
+
+        if (bufferSize >= _bufferMax) revert BufferFull(bufferSize, _bufferMax);
+        else if (pendingDai >= _minimumPayment) {
+            vest.vest(vestId);
+            
+            // Send DAI up to the maximum and the rest should go back into the surplus buffer
+            // Use the balance in case someone sends DAI directly to this contract (can be used in emergency)
+            uint256 daiBalance = dai.balanceOf(address(this));
+            if (daiBalance + bufferSize > _bufferMax) {
+                daiSent = _bufferMax - bufferSize;
+
+                // Send the rest back to the surplus buffer
+                daiJoin.join(vow, daiBalance - daiSent);
+            } else {
+                daiSent = daiBalance;
+            }
+            dai.transfer(address(treasury), daiSent);
+            totalSent += daiSent;
+
+            emit TopUp(bufferSize, daiBalance, daiSent, totalSent);
+        } else revert PendingDaiTooSmall(pendingDai, _minimumPayment);
+    }
+
+}

--- a/src/NetworkPaymentAdapter.sol
+++ b/src/NetworkPaymentAdapter.sol
@@ -29,6 +29,7 @@ interface DaiJoinLike {
 
 interface DaiLike {
     function balanceOf(address) external view returns (uint256);
+    function approve(address, uint256) external returns (bool);
     function transfer(address, uint256) external returns (bool);
 }
 
@@ -90,6 +91,8 @@ contract NetworkPaymentAdapter {
         daiJoin = DaiJoinLike(_daiJoin);
         dai = DaiLike(daiJoin.dai());
         vow = _vow;
+
+        dai.approve(address(daiJoin), type(uint256).max);
     }
 
     // --- Administration ---
@@ -98,7 +101,7 @@ contract NetworkPaymentAdapter {
             bufferMax = data;
         } else if (what == "minimumPayment") {
             minimumPayment = data;
-        } else revert InvalidFileParam(what);
+        } else revert("NetworkPaymentAdapter/file-unrecognized-param");
 
         emit File(what, data);
     }

--- a/src/NetworkPaymentAdapter.sol
+++ b/src/NetworkPaymentAdapter.sol
@@ -49,7 +49,7 @@ contract NetworkPaymentAdapter {
         emit Deny(usr);
     }
     modifier auth {
-        require(wards[msg.sender] == 1, "Sequencer/not-authorized");
+        require(wards[msg.sender] == 1, "NetworkPaymentAdapter/not-authorized");
         _;
     }
 
@@ -72,7 +72,7 @@ contract NetworkPaymentAdapter {
     event Rely(address indexed usr);
     event Deny(address indexed usr);
     event File(bytes32 indexed what, uint256 data);
-    event TopUp(uint256 bufferSize, uint256 daiBalance, uint256 daiSent, uint256 totalSent);
+    event TopUp(uint256 bufferSize, uint256 daiBalance, uint256 daiSent);
 
     // --- Errors ---
     error InvalidFileParam(bytes32 what);
@@ -130,7 +130,7 @@ contract NetworkPaymentAdapter {
             dai.transfer(address(treasury), daiSent);
             totalSent += daiSent;
 
-            emit TopUp(bufferSize, daiBalance, daiSent, totalSent);
+            emit TopUp(bufferSize, daiBalance, daiSent);
         } else revert PendingDaiTooSmall(pendingDai, _minimumPayment);
     }
 

--- a/src/NetworkPaymentAdapter.sol
+++ b/src/NetworkPaymentAdapter.sol
@@ -103,7 +103,10 @@ contract NetworkPaymentAdapter {
         emit File(what, data);
     }
 
-    // --- Pay the keeper treasury ---
+    /**
+     * @notice Top up the treasury with any outstanding DAI
+     * @dev Only callable from treasury. Call canTopUp() to see if this will pass.
+     */
     function topUp() external returns (uint256 daiSent) {
         if (msg.sender != address(treasury)) revert UnauthorizedSender(msg.sender);
 
@@ -132,6 +135,17 @@ contract NetworkPaymentAdapter {
 
             emit TopUp(bufferSize, daiBalance, daiSent);
         } else revert PendingDaiTooSmall(pendingDai, _minimumPayment);
+    }
+
+    /**
+     * @notice Check if we can call the topUp() function.
+     */
+    function canTopUp() external view returns (bool) {
+        uint256 bufferSize = treasury.getBufferSize();
+        uint256 pendingDai = vest.unpaid(vestId);
+        uint256 _minimumPayment = minimumPayment;
+
+        return (bufferSize + _minimumPayment < bufferMax) && (pendingDai >= _minimumPayment);
     }
 
 }

--- a/src/NetworkPaymentAdapter.sol
+++ b/src/NetworkPaymentAdapter.sol
@@ -104,8 +104,8 @@ contract NetworkPaymentAdapter {
 
     // --- Pay the keeper treasury ---
     function topUp() external returns (uint256 daiSent) {
-        uint256 pendingDai = vest.unpaid(vestId);
         uint256 bufferSize = treasury.getBufferSize();
+        uint256 pendingDai = vest.unpaid(vestId);
         uint256 _bufferMax = bufferMax;
         uint256 _minimumPayment = minimumPayment;
 

--- a/src/Sequencer.sol
+++ b/src/Sequencer.sol
@@ -75,7 +75,7 @@ contract Sequencer {
     error IndexTooHigh(uint256 index, uint256 length);
     error BadIndicies(uint256 startIndex, uint256 exclEndIndex);
 
-    constructor () {
+    constructor() {
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
     }

--- a/src/tests/NetworkPaymentAdapter.t.sol
+++ b/src/tests/NetworkPaymentAdapter.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2021 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity 0.8.13;
+
+import "dss-test/DSSTest.sol";
+
+import {DaiMock} from "./mocks/DaiMock.sol";
+import {DaiJoinMock} from "./mocks/DaiJoinMock.sol";
+import {VatMock} from "./mocks/VatMock.sol";
+import {NetworkPaymentAdapter} from "../NetworkPaymentAdapter.sol";
+
+contract VestMock {
+
+    mapping (uint256 => uint256) public vests;
+    DaiMock public dai;
+
+    constructor(DaiMock _dai) {
+        dai = DaiMock;
+    }
+
+    function setVest(uint256 id, uint256 amt) external {
+        vests[id] = amt;
+    }
+
+    function vest(uint256 id) external {
+        dai.transfer(msg.sender, vests[id]);
+        vests[id] = 0;
+    }
+
+    function unpaid(uint256 id) external view returns (uint256) {
+        return vests[id];
+    }
+
+}
+
+contract TreasuryMock {
+
+    NetworkPaymentAdapter public adapter;
+
+    constructor(NetworkPaymentAdapter _adapter) {
+        adapter = _adapter;
+    }
+
+    function topUp() external {
+        adapter.topUp();
+    }
+
+}
+
+contract NetworkPaymentAdapter is DSSTest {
+
+    VestMock vest;
+    TreasuryMock treasury;
+    DaiMock dai;
+    DaiJoinMock daiJoin;
+    VatMock vat;
+    address vow;
+
+    NetworkPaymentAdapter adapter;
+
+    function postSetup() internal virtual override {
+        vest = new VestMock();
+        treasury = new TreasuryMock();
+        dai = new DaiMock();
+        vat = new VatMock();
+        daiJoin = new DaiJoinMock(address(vat), address(dai));
+        vow = TEST_ADDRESS;
+
+        adapter = new NetworkPaymentAdapter(
+            address(vest),
+            123,
+            address(treasury),
+            address(daiJoin),
+            vow
+        );
+    }
+
+    function test_auth() public {
+        checkAuth(address(adapter), address(this));
+    }
+
+}

--- a/src/tests/mocks/DaiJoinMock.sol
+++ b/src/tests/mocks/DaiJoinMock.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// DaiJoin.sol -- Dai adapter
+
+// Copyright (C) 2018 Rain <rainbreak@riseup.net>
+// Copyright (C) 2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.13;
+
+interface DaiLike {
+    function burn(address,uint256) external;
+    function mint(address,uint256) external;
+}
+
+interface VatLike {
+    function move(address,address,uint256) external;
+}
+
+contract DaiJoinMock {
+    VatLike public immutable vat;       // CDP Engine
+    DaiLike public immutable dai;       // Stablecoin Token
+    uint256 constant RAY = 10 ** 27;
+
+    // --- Events ---
+    event Join(address indexed usr, uint256 wad);
+    event Exit(address indexed usr, uint256 wad);
+
+    constructor(address vat_, address dai_) {
+        vat = VatLike(vat_);
+        dai = DaiLike(dai_);
+    }
+
+    // --- User's functions ---
+    function join(address usr, uint256 wad) external {
+        vat.move(address(this), usr, RAY * wad);
+        dai.burn(msg.sender, wad);
+        emit Join(usr, wad);
+    }
+
+    function exit(address usr, uint256 wad) external {
+        vat.move(msg.sender, address(this), RAY * wad);
+        dai.mint(usr, wad);
+        emit Exit(usr, wad);
+    }
+}

--- a/src/tests/mocks/DaiMock.sol
+++ b/src/tests/mocks/DaiMock.sol
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// Dai.sol -- Dai token
+
+// Copyright (C) 2017, 2018, 2019 dbrock, rain, mrchico
+// Copyright (C) 2021-2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.13;
+
+interface IERC1271 {
+    function isValidSignature(
+        bytes32,
+        bytes memory
+    ) external view returns (bytes4);
+}
+
+contract DaiMock {
+    mapping (address => uint256) public wards;
+
+    // --- ERC20 Data ---
+    string  public constant name     = "Dai Stablecoin";
+    string  public constant symbol   = "DAI";
+    string  public constant version  = "3";
+    uint8   public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping (address => uint256)                      public balanceOf;
+    mapping (address => mapping (address => uint256)) public allowance;
+    mapping (address => uint256)                      public nonces;
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    // --- EIP712 niceties ---
+    uint256 public immutable deploymentChainId;
+    bytes32 private immutable _DOMAIN_SEPARATOR;
+    bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "Dai/not-authorized");
+        _;
+    }
+
+    constructor() {
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+
+        deploymentChainId = block.chainid;
+        _DOMAIN_SEPARATOR = _calculateDomainSeparator(block.chainid);
+    }
+
+    function _calculateDomainSeparator(uint256 chainId) private view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes(name)),
+                keccak256(bytes(version)),
+                chainId,
+                address(this)
+            )
+        );
+    }
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32) {
+        return block.chainid == deploymentChainId ? _DOMAIN_SEPARATOR : _calculateDomainSeparator(block.chainid);
+    }
+
+    // --- Administration ---
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    // --- ERC20 Mutations ---
+    function transfer(address to, uint256 value) external returns (bool) {
+        require(to != address(0) && to != address(this), "Dai/invalid-address");
+        uint256 balance = balanceOf[msg.sender];
+        require(balance >= value, "Dai/insufficient-balance");
+
+        unchecked {
+            balanceOf[msg.sender] = balance - value;
+            balanceOf[to] += value;
+        }
+
+        emit Transfer(msg.sender, to, value);
+
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        require(to != address(0) && to != address(this), "Dai/invalid-address");
+        uint256 balance = balanceOf[from];
+        require(balance >= value, "Dai/insufficient-balance");
+
+        if (from != msg.sender) {
+            uint256 allowed = allowance[from][msg.sender];
+            if (allowed != type(uint256).max) {
+                require(allowed >= value, "Dai/insufficient-allowance");
+
+                unchecked {
+                    allowance[from][msg.sender] = allowed - value;
+                }
+            }
+        }
+
+        unchecked {
+            balanceOf[from] = balance - value;
+            balanceOf[to] += value;
+        }
+
+        emit Transfer(from, to, value);
+
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        allowance[msg.sender][spender] = value;
+
+        emit Approval(msg.sender, spender, value);
+
+        return true;
+    }
+
+    function increaseAllowance(address spender, uint256 addedValue) external returns (bool) {
+        uint256 newValue = allowance[msg.sender][spender] + addedValue;
+        allowance[msg.sender][spender] = newValue;
+
+        emit Approval(msg.sender, spender, newValue);
+
+        return true;
+    }
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) external returns (bool) {
+        uint256 allowed = allowance[msg.sender][spender];
+        require(allowed >= subtractedValue, "Dai/insufficient-allowance");
+        unchecked{
+            allowed = allowed - subtractedValue;
+        }
+        allowance[msg.sender][spender] = allowed;
+
+        emit Approval(msg.sender, spender, allowed);
+
+        return true;
+    }
+
+    // --- Mint/Burn ---
+    function mint(address to, uint256 value) external auth {
+        require(to != address(0) && to != address(this), "Dai/invalid-address");
+        unchecked {
+            balanceOf[to] = balanceOf[to] + value; // note: we don't need an overflow check here b/c balanceOf[to] <= totalSupply and there is an overflow check below
+        }
+        totalSupply = totalSupply + value;
+
+        emit Transfer(address(0), to, value);
+    }
+
+    function burn(address from, uint256 value) external {
+        uint256 balance = balanceOf[from];
+        require(balance >= value, "Dai/insufficient-balance");
+
+        if (from != msg.sender) {
+            uint256 allowed = allowance[from][msg.sender];
+            if (allowed != type(uint256).max) {
+                require(allowed >= value, "Dai/insufficient-allowance");
+
+                unchecked {
+                    allowance[from][msg.sender] = allowed - value;
+                }
+            }
+        }
+
+        unchecked {
+            balanceOf[from] = balance - value; // note: we don't need overflow checks b/c require(balance >= value) and balance <= totalSupply
+            totalSupply     = totalSupply - value;
+        }
+
+        emit Transfer(from, address(0), value);
+    }
+
+    // --- Approve by signature ---
+
+    function _isValidSignature(
+        address signer,
+        bytes32 digest,
+        bytes memory signature
+    ) internal view returns (bool) {
+        if (signature.length == 65) {
+            bytes32 r;
+            bytes32 s;
+            uint8 v;
+            assembly {
+                r := mload(add(signature, 0x20))
+                s := mload(add(signature, 0x40))
+                v := byte(0, mload(add(signature, 0x60)))
+            }
+            if (signer == ecrecover(digest, v, r, s)) {
+                return true;
+            }
+        }
+
+        (bool success, bytes memory result) = signer.staticcall(
+            abi.encodeWithSelector(IERC1271.isValidSignature.selector, digest, signature)
+        );
+        return (success &&
+            result.length == 32 &&
+            abi.decode(result, (bytes4)) == IERC1271.isValidSignature.selector);
+    }
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        bytes memory signature
+    ) public {
+        require(block.timestamp <= deadline, "Dai/permit-expired");
+        require(owner != address(0), "Dai/invalid-owner");
+
+        uint256 nonce;
+        unchecked { nonce = nonces[owner]++; }
+
+        bytes32 digest =
+            keccak256(abi.encodePacked(
+                "\x19\x01",
+                block.chainid == deploymentChainId ? _DOMAIN_SEPARATOR : _calculateDomainSeparator(block.chainid),
+                keccak256(abi.encode(
+                    PERMIT_TYPEHASH,
+                    owner,
+                    spender,
+                    value,
+                    nonce,
+                    deadline
+                ))
+            ));
+
+        require(_isValidSignature(owner, digest, signature), "Dai/invalid-permit");
+
+        allowance[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        permit(owner, spender, value, deadline, abi.encodePacked(r, s, v));
+    }
+}

--- a/src/tests/mocks/VatMock.sol
+++ b/src/tests/mocks/VatMock.sol
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// vat.sol -- Dai CDP database
+
+// Copyright (C) 2018 Rain <rainbreak@riseup.net>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.13;
+
+contract VatMock {
+    // --- Data ---
+    mapping (address => uint256) public wards;
+
+    mapping(address => mapping (address => uint256)) public can;
+
+    struct Ilk {
+        uint256 Art;   // Total Normalised Debt     [wad]
+        uint256 rate;  // Accumulated Rates         [ray]
+        uint256 spot;  // Price with Safety Margin  [ray]
+        uint256 line;  // Debt Ceiling              [rad]
+        uint256 dust;  // Urn Debt Floor            [rad]
+    }
+    struct Urn {
+        uint256 ink;   // Locked Collateral  [wad]
+        uint256 art;   // Normalised Debt    [wad]
+    }
+
+    mapping (bytes32 => Ilk)                            public ilks;
+    mapping (bytes32 => mapping (address => Urn))       public urns;
+    mapping (bytes32 => mapping (address => uint256))   public gem;  // [wad]
+    mapping (address => uint256)                        public dai;  // [rad]
+    mapping (address => uint256)                        public sin;  // [rad]
+
+    uint256 public debt;  // Total Dai Issued    [rad]
+    uint256 public vice;  // Total Unbacked Dai  [rad]
+    uint256 public Line;  // Total Debt Ceiling  [rad]
+    uint256 public live;  // Active Flag
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+    event Init(bytes32 indexed ilk);
+    event File(bytes32 indexed what, uint256 data);
+    event File(bytes32 indexed ilk, bytes32 indexed what, uint256 data);
+    event Cage();
+    event Hope(address indexed from, address indexed to);
+    event Nope(address indexed from, address indexed to);
+    event Slip(bytes32 indexed ilk, address indexed usr, int256 wad);
+    event Flux(bytes32 indexed ilk, address indexed src, address indexed dst, uint256 wad);
+    event Move(address indexed src, address indexed dst, uint256 rad);
+    event Frob(bytes32 indexed i, address indexed u, address v, address w, int256 dink, int256 dart);
+    event Fork(bytes32 indexed ilk, address indexed src, address indexed dst, int256 dink, int256 dart);
+    event Grab(bytes32 indexed i, address indexed u, address v, address w, int256 dink, int256 dart);
+    event Heal(address indexed u, uint256 rad);
+    event Suck(address indexed u, address indexed v, uint256 rad);
+    event Fold(bytes32 indexed i, address indexed u, int256 rate);
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "Vat/not-authorized");
+        _;
+    }
+
+    function wish(address bit, address usr) internal view returns (bool) {
+        return either(bit == usr, can[bit][usr] == 1);
+    }
+
+    // --- Init ---
+    constructor() {
+        wards[msg.sender] = 1;
+        live = 1;
+        emit Rely(msg.sender);
+    }
+
+    // --- Math ---
+    string private constant ARITHMETIC_ERROR = string(abi.encodeWithSignature("Panic(uint256)", 0x11));
+    function _add(uint256 x, int256 y) internal pure returns (uint256 z) {
+        unchecked {
+            z = x + uint256(y);
+        }
+        require(y >= 0 || z <= x, ARITHMETIC_ERROR);
+        require(y <= 0 || z >= x, ARITHMETIC_ERROR);
+    }
+    function _sub(uint256 x, int256 y) internal pure returns (uint256 z) {
+        unchecked {
+            z = x - uint256(y);
+        }
+        require(y <= 0 || z <= x, ARITHMETIC_ERROR);
+        require(y >= 0 || z >= x, ARITHMETIC_ERROR);
+    }
+    function _int256(uint256 x) internal pure returns (int256 y) {
+        require((y = int256(x)) >= 0, ARITHMETIC_ERROR);
+    }
+
+    // --- Administration ---
+    function rely(address usr) external auth {
+        require(live == 1, "Vat/not-live");
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+
+    function deny(address usr) external auth {
+        require(live == 1, "Vat/not-live");
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    function init(bytes32 ilk) external auth {
+        require(ilks[ilk].rate == 0, "Vat/ilk-already-init");
+        ilks[ilk].rate = 10 ** 27;
+        emit Init(ilk);
+    }
+
+    function file(bytes32 what, uint256 data) external auth {
+        require(live == 1, "Vat/not-live");
+        if (what == "Line") Line = data;
+        else revert("Vat/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    function file(bytes32 ilk, bytes32 what, uint256 data) external auth {
+        require(live == 1, "Vat/not-live");
+        if (what == "spot") ilks[ilk].spot = data;
+        else if (what == "line") ilks[ilk].line = data;
+        else if (what == "dust") ilks[ilk].dust = data;
+        else revert("Vat/file-unrecognized-param");
+        emit File(ilk, what, data);
+    }
+
+    function cage() external auth {
+        live = 0;
+        emit Cage();
+    }
+
+    // --- Structs getters ---
+    function Art(bytes32 ilk) external view returns (uint256 Art_) {
+        Art_ = ilks[ilk].Art;
+    }
+
+    function rate(bytes32 ilk) external view returns (uint256 rate_) {
+        rate_ = ilks[ilk].rate;
+    }
+
+    function spot(bytes32 ilk) external view returns (uint256 spot_) {
+        spot_ = ilks[ilk].spot;
+    }
+
+    function line(bytes32 ilk) external view returns (uint256 line_) {
+        line_ = ilks[ilk].line;
+    }
+
+    function dust(bytes32 ilk) external view returns (uint256 dust_) {
+        dust_ = ilks[ilk].dust;
+    }
+
+    function ink(bytes32 ilk, address urn) external view returns (uint256 ink_) {
+        ink_ = urns[ilk][urn].ink;
+    }
+
+    function art(bytes32 ilk, address urn) external view returns (uint256 art_) {
+        art_ = urns[ilk][urn].art;
+    }
+
+    // --- Allowance ---
+    function hope(address usr) external {
+        can[msg.sender][usr] = 1;
+        emit Hope(msg.sender, usr);
+    }
+
+    function nope(address usr) external {
+        can[msg.sender][usr] = 0;
+        emit Nope(msg.sender, usr);
+    }
+
+    // --- Fungibility ---
+    function slip(bytes32 ilk, address usr, int256 wad) external auth {
+        gem[ilk][usr] = _add(gem[ilk][usr], wad);
+        emit Slip(ilk, usr, wad);
+    }
+
+    function flux(bytes32 ilk, address src, address dst, uint256 wad) external {
+        require(wish(src, msg.sender), "Vat/not-allowed");
+        gem[ilk][src] = gem[ilk][src] - wad;
+        gem[ilk][dst] = gem[ilk][dst] + wad;
+        emit Flux(ilk, src, dst, wad);
+    }
+
+    function move(address src, address dst, uint256 rad) external {
+        require(wish(src, msg.sender), "Vat/not-allowed");
+        dai[src] = dai[src] - rad;
+        dai[dst] = dai[dst] + rad;
+        emit Move(src, dst, rad);
+    }
+
+    function either(bool x, bool y) internal pure returns (bool z) {
+        assembly{ z := or(x, y)}
+    }
+
+    function both(bool x, bool y) internal pure returns (bool z) {
+        assembly{ z := and(x, y)}
+    }
+
+    // --- CDP Manipulation ---
+    function frob(bytes32 i, address u, address v, address w, int256 dink, int256 dart) external {
+        // system is live
+        require(live == 1, "Vat/not-live");
+
+        uint256 rate_ = ilks[i].rate;
+        // ilk has been initialised
+        require(rate_ != 0, "Vat/ilk-not-init");
+
+        Urn memory urn = urns[i][u];
+        urn.ink = _add(urn.ink, dink);
+        urn.art = _add(urn.art, dart);
+
+        uint256 Art_  = _add(ilks[i].Art, dart);
+        int256  dtab  = _int256(rate_) * dart;
+        uint256 debt_ = _add(debt, dtab);
+
+        // either debt has decreased, or debt ceilings are not exceeded
+        require(either(dart <= 0, both(Art_ * rate_ <= ilks[i].line, debt_ <= Line)), "Vat/ceiling-exceeded");
+        uint256 tab = rate_ * urn.art;
+        // urn is either less risky than before, or it is safe
+        require(either(both(dart <= 0, dink >= 0), tab <= urn.ink * ilks[i].spot), "Vat/not-safe");
+
+        // urn is either more safe, or the owner consents
+        require(either(both(dart <= 0, dink >= 0), wish(u, msg.sender)), "Vat/not-allowed-u");
+        // collateral src consents
+        require(either(dink <= 0, wish(v, msg.sender)), "Vat/not-allowed-v");
+        // debt dst consents
+        require(either(dart >= 0, wish(w, msg.sender)), "Vat/not-allowed-w");
+
+        // urn has no debt, or a non-dusty amount
+        require(either(urn.art == 0, tab >= ilks[i].dust), "Vat/dust");
+
+        // update storage values
+        gem[i][v]   = _sub(gem[i][v], dink);
+        dai[w]      = _add(dai[w],    dtab);
+        urns[i][u]  = urn;
+        ilks[i].Art = Art_;
+        debt        = debt_;
+
+        emit Frob(i, u, v, w, dink, dart);
+    }
+
+    // --- CDP Fungibility ---
+    function fork(bytes32 ilk, address src, address dst, int256 dink, int256 dart) external {
+        Urn storage u = urns[ilk][src];
+        Urn storage v = urns[ilk][dst];
+        Ilk storage i = ilks[ilk];
+
+        u.ink = _sub(u.ink, dink);
+        u.art = _sub(u.art, dart);
+        v.ink = _add(v.ink, dink);
+        v.art = _add(v.art, dart);
+
+        uint256 utab = u.art * i.rate;
+        uint256 vtab = v.art * i.rate;
+
+        // both sides consent
+        require(both(wish(src, msg.sender), wish(dst, msg.sender)), "Vat/not-allowed");
+
+        // both sides safe
+        require(utab <= u.ink * i.spot, "Vat/not-safe-src");
+        require(vtab <= v.ink * i.spot, "Vat/not-safe-dst");
+
+        // both sides non-dusty
+        require(either(utab >= i.dust, u.art == 0), "Vat/dust-src");
+        require(either(vtab >= i.dust, v.art == 0), "Vat/dust-dst");
+
+        emit Fork(ilk, src, dst, dink, dart);
+    }
+
+    // --- CDP Confiscation ---
+    function grab(bytes32 i, address u, address v, address w, int256 dink, int256 dart) external auth {
+        Urn storage urn = urns[i][u];
+        Ilk storage ilk = ilks[i];
+
+        urn.ink = _add(urn.ink, dink);
+        urn.art = _add(urn.art, dart);
+        ilk.Art = _add(ilk.Art, dart);
+
+        int256 dtab = _int256(ilk.rate) * dart;
+
+        gem[i][v] = _sub(gem[i][v], dink);
+        sin[w]    = _sub(sin[w],    dtab);
+        vice      = _sub(vice,      dtab);
+
+        emit Grab(i, u, v, w, dink, dart);
+    }
+
+    // --- Settlement ---
+    function heal(uint256 rad) external {
+        address u = msg.sender;
+        sin[u] = sin[u] - rad;
+        dai[u] = dai[u] - rad;
+        vice   = vice   - rad;
+        debt   = debt   - rad;
+
+        emit Heal(msg.sender, rad);
+    }
+
+    function suck(address u, address v, uint256 rad) external auth {
+        sin[u] = sin[u] + rad;
+        dai[v] = dai[v] + rad;
+        vice   = vice   + rad;
+        debt   = debt   + rad;
+
+        emit Suck(u, v, rad);
+    }
+
+    // --- Rates ---
+    function fold(bytes32 i, address u, int256 rate_) external auth {
+        require(live == 1, "Vat/not-live");
+        Ilk storage ilk = ilks[i];
+        ilk.rate    = _add(ilk.rate, rate_);
+        int256 rad  = _int256(ilk.Art) * rate_;
+        dai[u]      = _add(dai[u], rad);
+        debt        = _add(debt,   rad);
+
+        emit Fold(i, u, rate_);
+    }
+}


### PR DESCRIPTION
As explained here: https://github.com/makerdao/dss-cron/issues/16

This simplifies the payment process such that Keeper Networks only need to report their DAI-equivalent treasury balance via the `getBufferSize()` function. We also remove the `Buffer Min` parameter as it never made sense. Instead we set a minimum payment amount to prevent waste of gas / spam.

Keeper Networks can then call `topUp()` function to pull in DAI, and they can pay themselves with some portion of the DAI coming in.

Initial mockup. This needs tests, but want confirmation from all Keeper Networks that this is an appropriate interface.