### PR TITLE
Sequencer Supports Non-Uniform Execution Windows

### DIFF
--- a/src/Sequencer.sol
+++ b/src/Sequencer.sol
@@ -99,7 +99,7 @@ contract Sequencer {
         if (!networks.add(network)) revert NetworkExists(network);
         if (windowSize == 0) revert WindowZero(network);
         windows[network] = Window({
-            start: 0,
+            start: 0,               // start will be set in refreshStarts
             length: windowSize
         });
         totalWindowSize += windowSize;
@@ -135,7 +135,7 @@ contract Sequencer {
     }
     function getMaster() external view returns (bytes32) {
         uint256 netLen = networks.length();
-        if (networks.length() == 0) return bytes32(0);
+        if (netLen == 0) return bytes32(0);
 
         uint256 pos = block.number % totalWindowSize;
         for (uint256 i = 0; i < netLen; i++) {

--- a/src/tests/DssCronBase.t.sol
+++ b/src/tests/DssCronBase.t.sol
@@ -43,13 +43,15 @@ abstract contract DssCronBaseTest is DSSTest {
         dss = MCD.loadFromChainlog(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
         
         sequencer = new Sequencer();
-        sequencer.file("window", 12);       // Give 12 block window for each network (~3 mins)
-        assertEq(sequencer.window(), 12);
 
         ilkRegistry = IlkRegistryAbstract(dss.chainlog.getAddress("ILK_REGISTRY"));
         
         // Add a default network
-        sequencer.addNetwork(NET_A);
+        sequencer.addNetwork(NET_A, 13);
+        assertEq(sequencer.totalWindowSize(), 13);
+        (uint256 start, uint256 length) = sequencer.windows(NET_A);
+        assertEq(start, 0);
+        assertEq(length, 13);
 
         // Add a default user
         user = dss.newUser();

--- a/src/tests/Sequencer.t.sol
+++ b/src/tests/Sequencer.t.sol
@@ -68,6 +68,8 @@ contract SequencerTest is DssCronBaseTest {
 
     function test_add_remove_network() public {
         sequencer.addNetwork(NET_A, 123);
+        vm.expectEmit(true, true, true, true);
+        emit RemoveNetwork(NET_A);
         sequencer.removeNetwork(NET_A);
 
         assertTrue(!sequencer.hasNetwork(NET_A));
@@ -78,7 +80,7 @@ contract SequencerTest is DssCronBaseTest {
 
     function test_remove_non_existent_network() public {
         sequencer.addNetwork(NET_A, 123);
-        GodMode.vm().expectRevert(abi.encodeWithSignature("NetworkDoesNotExist(bytes32)", NET_B));
+        vm.expectRevert(abi.encodeWithSignature("NetworkDoesNotExist(bytes32)", NET_B));
         sequencer.removeNetwork(NET_B);
     }
 
@@ -157,6 +159,8 @@ contract SequencerTest is DssCronBaseTest {
     }
 
     function test_add_job() public {
+        vm.expectEmit(true, true, true, true);
+        emit AddJob(ADDR0);
         sequencer.addJob(ADDR0);
 
         assertEq(sequencer.jobAt(0), ADDR0);
@@ -166,12 +170,14 @@ contract SequencerTest is DssCronBaseTest {
 
     function test_add_dupe_job() public {
         sequencer.addJob(ADDR0);
-        GodMode.vm().expectRevert(abi.encodeWithSignature("JobExists(address)", ADDR0));
+        vm.expectRevert(abi.encodeWithSignature("JobExists(address)", ADDR0));
         sequencer.addJob(ADDR0);
     }
 
     function test_add_remove_job() public {
         sequencer.addJob(ADDR0);
+        vm.expectEmit(true, true, true, true);
+        emit RemoveJob(ADDR0);
         sequencer.removeJob(ADDR0);
 
         assertTrue(!sequencer.hasJob(ADDR0));
@@ -180,7 +186,7 @@ contract SequencerTest is DssCronBaseTest {
 
     function test_remove_non_existent_job() public {
         sequencer.addJob(ADDR0);
-        GodMode.vm().expectRevert(abi.encodeWithSignature("JobDoesNotExist(address)", ADDR1));
+        vm.expectRevert(abi.encodeWithSignature("JobDoesNotExist(address)", ADDR1));
         sequencer.removeJob(ADDR1);
     }
 

--- a/src/tests/Sequencer.t.sol
+++ b/src/tests/Sequencer.t.sol
@@ -19,52 +19,82 @@ import "./DssCronBase.t.sol";
 
 contract SequencerTest is DssCronBaseTest {
 
-    address constant ADDR0 = address(0);
-    address constant ADDR1 = address(1);
-    address constant ADDR2 = address(2);
+    address constant ADDR0 = address(123);
+    address constant ADDR1 = address(456);
+    address constant ADDR2 = address(789);
+
+    event AddNetwork(bytes32 indexed network, uint256 windowSize);
+    event RemoveNetwork(bytes32 indexed network);
+    event AddJob(address indexed job);
+    event RemoveJob(address indexed job);
 
     function setUpSub() virtual override internal {
         // Remove the default network
         sequencer.removeNetwork(NET_A);
     }
 
+    function test_auth() public {
+        checkAuth(address(sequencer), "Sequencer");
+    }
+
+    function checkWindow(bytes32 network, uint256 start, uint256 length) internal {
+        (uint256 _start, uint256 _length) = sequencer.windows(network);
+        assertEq(_start, start);
+        assertEq(_length, length);
+    }
+
     function test_add_network() public {
-        sequencer.addNetwork(NET_A);
+        vm.expectEmit(true, true, true, true);
+        emit AddNetwork(NET_A, 123);
+        sequencer.addNetwork(NET_A, 123);
 
         assertEq(sequencer.networkAt(0), NET_A);
         assertTrue(sequencer.hasNetwork(NET_A));
         assertEq(sequencer.numNetworks(), 1);
+        assertEq(sequencer.totalWindowSize(), 123);
+        checkWindow(NET_A, 0, 123);
     }
 
     function test_add_dupe_network() public {
-        sequencer.addNetwork(NET_A);
-        GodMode.vm().expectRevert(abi.encodeWithSignature("NetworkExists(bytes32)", NET_A));
-        sequencer.addNetwork(NET_A);
+        sequencer.addNetwork(NET_A, 123);
+        vm.expectRevert(abi.encodeWithSignature("NetworkExists(bytes32)", NET_A));
+        sequencer.addNetwork(NET_A, 123);
+    }
+
+    function test_add_network_zero_window() public {
+        vm.expectRevert(abi.encodeWithSignature("WindowZero(bytes32)", NET_A));
+        sequencer.addNetwork(NET_A, 0);
     }
 
     function test_add_remove_network() public {
-        sequencer.addNetwork(NET_A);
+        sequencer.addNetwork(NET_A, 123);
         sequencer.removeNetwork(NET_A);
 
         assertTrue(!sequencer.hasNetwork(NET_A));
         assertEq(sequencer.numNetworks(), 0);
+        assertEq(sequencer.totalWindowSize(), 0);
+        checkWindow(NET_A, 0, 0);
     }
 
     function test_remove_non_existent_network() public {
-        sequencer.addNetwork(NET_A);
+        sequencer.addNetwork(NET_A, 123);
         GodMode.vm().expectRevert(abi.encodeWithSignature("NetworkDoesNotExist(bytes32)", NET_B));
         sequencer.removeNetwork(NET_B);
     }
 
     function test_add_remove_networks() public {
-        sequencer.addNetwork(NET_A);
-        sequencer.addNetwork(NET_B);
-        sequencer.addNetwork(NET_C);
+        sequencer.addNetwork(NET_A, 10);
+        sequencer.addNetwork(NET_B, 20);
+        sequencer.addNetwork(NET_C, 30);
 
         assertEq(sequencer.numNetworks(), 3);
         assertEq(sequencer.networkAt(0), NET_A);
         assertEq(sequencer.networkAt(1), NET_B);
         assertEq(sequencer.networkAt(2), NET_C);
+        assertEq(sequencer.totalWindowSize(), 60);
+        checkWindow(NET_A, 0, 10);
+        checkWindow(NET_B, 10, 20);
+        checkWindow(NET_C, 30, 30);
 
         // Should move NET_C (last element) to slot 0
         sequencer.removeNetwork(NET_A);
@@ -72,17 +102,24 @@ contract SequencerTest is DssCronBaseTest {
         assertEq(sequencer.numNetworks(), 2);
         assertEq(sequencer.networkAt(0), NET_C);
         assertEq(sequencer.networkAt(1), NET_B);
+        assertEq(sequencer.totalWindowSize(), 50);
+        checkWindow(NET_C, 0, 30);
+        checkWindow(NET_B, 30, 20);
     }
 
     function test_add_remove_networks_last() public {
-        sequencer.addNetwork(NET_A);
-        sequencer.addNetwork(NET_B);
-        sequencer.addNetwork(NET_C);
+        sequencer.addNetwork(NET_A, 10);
+        sequencer.addNetwork(NET_B, 20);
+        sequencer.addNetwork(NET_C, 10);
 
         assertEq(sequencer.numNetworks(), 3);
         assertEq(sequencer.networkAt(0), NET_A);
         assertEq(sequencer.networkAt(1), NET_B);
         assertEq(sequencer.networkAt(2), NET_C);
+        assertEq(sequencer.totalWindowSize(), 40);
+        checkWindow(NET_A, 0, 10);
+        checkWindow(NET_B, 10, 20);
+        checkWindow(NET_C, 30, 10);
 
         // Should remove the last element and not re-arrange
         sequencer.removeNetwork(NET_C);
@@ -90,26 +127,32 @@ contract SequencerTest is DssCronBaseTest {
         assertEq(sequencer.numNetworks(), 2);
         assertEq(sequencer.networkAt(0), NET_A);
         assertEq(sequencer.networkAt(1), NET_B);
+        assertEq(sequencer.totalWindowSize(), 30);
+        checkWindow(NET_A, 0, 10);
+        checkWindow(NET_B, 10, 20);
     }
 
     function test_rotation() public {
-        sequencer.addNetwork(NET_A);
-        sequencer.addNetwork(NET_B);
-        sequencer.addNetwork(NET_C);
+        sequencer.addNetwork(NET_A, 3);
+        sequencer.addNetwork(NET_B, 7);
+        sequencer.addNetwork(NET_C, 25);
 
         bytes32[3] memory networks = [NET_A, NET_B, NET_C];
 
-        for (uint256 i = 0; i < sequencer.window() * 10; i++) {
-            assertTrue(sequencer.isMaster(networks[0]) == ((block.number / sequencer.window()) % sequencer.numNetworks() == 0));
-            assertTrue(sequencer.isMaster(networks[1]) == ((block.number / sequencer.window()) % sequencer.numNetworks() == 1));
-            assertTrue(sequencer.isMaster(networks[2]) == ((block.number / sequencer.window()) % sequencer.numNetworks() == 2));
+        for (uint256 i = 0; i < sequencer.totalWindowSize() * 10; i++) {
+            bytes32 master = sequencer.getMaster();
+            uint256 pos = block.number % sequencer.totalWindowSize();
+            assertTrue(sequencer.isMaster(master));
+            assertTrue(sequencer.isMaster(networks[0]) == (pos >= 0 && pos < 3));
+            assertTrue(sequencer.isMaster(networks[1]) == (pos >= 3 && pos < 10));
+            assertTrue(sequencer.isMaster(networks[2]) == (pos >= 10 && pos < 35));
             assertEq(
                 (sequencer.isMaster(networks[0]) ? 1 : 0) +
                 (sequencer.isMaster(networks[1]) ? 1 : 0) +
                 (sequencer.isMaster(networks[2]) ? 1 : 0)
             , 1);       // Only one active at a time
 
-            GodMode.vm().roll(block.number + 1);
+            vm.roll(block.number + 1);
         }
     }
 


### PR DESCRIPTION
This will allow Maker governance to give different windows of execution for different networks instead of assuming all use the same. Some networks may be performing better and we want to prioritize them.