### PR TITLE
d3m job to either trigger or revert

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Sequencer: [0x238b4E35dAed6100C6162fAE4510261f88996EC9](https://etherscan.io/add
 
 AutoLineJob [thi=1000 bps, tlo=5000 bps]: [0x67AD4000e73579B9725eE3A149F85C4Af0A61361](https://etherscan.io/address/0x67AD4000e73579B9725eE3A149F85C4Af0A61361#code)  
 LerpJob [maxDuration=1 day]: [0x8F8f2FC1F0380B9Ff4fE5c3142d0811aC89E32fB](https://etherscan.io/address/0x8F8f2FC1F0380B9Ff4fE5c3142d0811aC89E32fB#code)  
-D3MJob [threshold=500 bps, ttl=10 minutes]: [0x1Bb799509b0B039345f910dfFb71eEfAc7022323](https://etherscan.io/address/0x1Bb799509b0B039345f910dfFb71eEfAc7022323#code)  
+D3MJob [threshold=500 bps, ttl=10 minutes]: [0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF](https://etherscan.io/address/0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF#code)  
 ClipperMomJob: [0xc3A76B34CFBdA7A3a5215629a0B937CBDEC7C71a](https://etherscan.io/address/0xc3A76B34CFBdA7A3a5215629a0B937CBDEC7C71a#code)  
 OracleJob: [0xe717Ec34b2707fc8c226b34be5eae8482d06ED03](https://etherscan.io/address/0xe717Ec34b2707fc8c226b34be5eae8482d06ED03#code)  
 

--- a/src/D3MJob.sol
+++ b/src/D3MJob.sol
@@ -102,20 +102,10 @@ contract D3MJob is IJob {
 
         bytes32[] memory ilks = ilkRegistry.list();
         for (uint256 i = 0; i < ilks.length; i++) {
-            bytes32 ilk = ilks[i];
-            address pool = hub.pool(ilk);
-
-            if (pool == address(0)) continue;     // Is this a D3M?
-
-            // Execute the D3M and see if the assets deployed change enough to warrant an update
-            (, uint256 part) = vat.urns(ilk, pool);
-            try hub.exec(ilk) {
-                (, uint256 nart) = vat.urns(ilk, pool);
-                if (block.timestamp < expiry[ilk]) continue;
-                if (!shouldTrigger(part, nart)) continue;
-
+            bytes memory args = abi.encode(ilks[i]);
+            try this.work(network, args) {
                 // Found a valid execution
-                return (true, abi.encode(ilk));
+                return (true, args);
             } catch {
                 // For some reason this errored -- carry on
             }


### PR DESCRIPTION
This PR fixes a bug whereby calling `workable()` on the D3M job could cause a state change (in `hub.exec(ilk)`) that was not reverted when `shouldTrigger` returned `false`. As a result, if the D3M job is not the very last job in the storage set `jobs` of the `Sequencer`, any subsequent job could see an invalid state when [`job.workable()` is called](https://github.com/makerdao/dss-cron/blob/22e793e5b03c851e0b8d42c0400c511d3f77afc9/src/Sequencer.sol#L180). This could cause that subsequent job to appear workable (e.g. due to the surplus buffer appearing larger than it actually is) when it should in fact be non-workable.

To fix the issue, this PR makes sure that no state change occurs when the D3M job reports being non-workable.