### PR TITLE
Make error messages more precise

### DIFF
--- a/src/LitePsmJob.sol
+++ b/src/LitePsmJob.sol
@@ -41,7 +41,8 @@ contract LitePsmJob is IJob {
 
     // --- Errors ---
     error NotMaster(bytes32 network);
-    error UnsupportedFunctionOrThresholdNotReached(bytes4 fn);
+    error ThresholdNotReached(bytes4 fn);
+    error UnsupportedFunction(bytes4 fn);
 
     // --- Events ---
     event Work(bytes32 indexed network, bytes4 indexed action);
@@ -65,14 +66,17 @@ contract LitePsmJob is IJob {
 
         (bytes4 fn) = abi.decode(args, (bytes4));
 
-        if (fn == litePsm.fill.selector && litePsm.rush() > rushThreshold) {
-            litePsm.fill();
-        } else if (fn == litePsm.chug.selector && litePsm.cut() > cutThreshold) {
-            litePsm.chug();
-        } else if (fn == litePsm.trim.selector && litePsm.gush() > gushThreshold) {
-            litePsm.trim();
+        if (fn == litePsm.fill.selector) {
+            if (litePsm.rush() > rushThreshold) litePsm.fill();
+            else revert ThresholdNotReached(fn);
+        } else if (fn == litePsm.chug.selector) {
+            if(litePsm.cut() > cutThreshold) litePsm.chug();
+            else revert ThresholdNotReached(fn);
+        } else if (fn == litePsm.trim.selector) {
+            if (litePsm.gush() > gushThreshold) litePsm.trim();
+            else revert ThresholdNotReached(fn);
         } else {
-            revert UnsupportedFunctionOrThresholdNotReached(fn);
+            revert UnsupportedFunction(fn);
         }
 
         emit Work(network, fn);

--- a/src/LitePsmJob.sol
+++ b/src/LitePsmJob.sol
@@ -67,13 +67,13 @@ contract LitePsmJob is IJob {
         (bytes4 fn) = abi.decode(args, (bytes4));
 
         if (fn == litePsm.fill.selector) {
-            if (litePsm.rush() > rushThreshold) litePsm.fill();
+            if (litePsm.rush() >= rushThreshold) litePsm.fill();
             else revert ThresholdNotReached(fn);
         } else if (fn == litePsm.chug.selector) {
-            if(litePsm.cut() > cutThreshold) litePsm.chug();
+            if(litePsm.cut() >= cutThreshold) litePsm.chug();
             else revert ThresholdNotReached(fn);
         } else if (fn == litePsm.trim.selector) {
-            if (litePsm.gush() > gushThreshold) litePsm.trim();
+            if (litePsm.gush() >= gushThreshold) litePsm.trim();
             else revert ThresholdNotReached(fn);
         } else {
             revert UnsupportedFunction(fn);
@@ -85,11 +85,11 @@ contract LitePsmJob is IJob {
     function workable(bytes32 network) external view override returns (bool, bytes memory) {
         if (!sequencer.isMaster(network)) return (false, bytes("Network is not master"));
 
-        if (litePsm.rush() > rushThreshold) {
+        if (litePsm.rush() >= rushThreshold) {
             return (true, abi.encode(litePsm.fill.selector));
-        } else if (litePsm.cut() > cutThreshold) {
+        } else if (litePsm.cut() >= cutThreshold) {
             return (true, abi.encode(litePsm.chug.selector));
-        } else if (litePsm.gush() > gushThreshold) {
+        } else if (litePsm.gush() >= gushThreshold) {
             return (true, abi.encode(litePsm.trim.selector));
         } else {
             return (false, bytes("No work to do"));

--- a/src/LitePsmJob.sol
+++ b/src/LitePsmJob.sol
@@ -41,7 +41,7 @@ contract LitePsmJob is IJob {
 
     // --- Errors ---
     error NotMaster(bytes32 network);
-    error UnsupportedFunction(bytes4 fn);
+    error UnsupportedFunctionOrThresholdNotReached(bytes4 fn);
 
     // --- Events ---
     event Work(bytes32 indexed network, bytes4 indexed action);
@@ -72,7 +72,7 @@ contract LitePsmJob is IJob {
         } else if (fn == litePsm.trim.selector && litePsm.gush() > gushThreshold) {
             litePsm.trim();
         } else {
-            revert UnsupportedFunction(fn);
+            revert UnsupportedFunctionOrThresholdNotReached(fn);
         }
 
         emit Work(network, fn);

--- a/src/tests/LitePsmJob-integration.t.sol
+++ b/src/tests/LitePsmJob-integration.t.sol
@@ -174,7 +174,14 @@ contract LitePsmJobIntegrationTest is DssCronBaseTest {
     function test_unsupported_function() public {
         bytes4 fn = 0x00000000;
         bytes memory args = abi.encode(fn);
-        vm.expectRevert(abi.encodeWithSelector(LitePsmJob.UnsupportedFunction.selector, fn));
+        vm.expectRevert(abi.encodeWithSelector(LitePsmJob.UnsupportedFunctionOrThresholdNotReached.selector, fn));
+        litePsmJob.work(NET_A, args);
+    }
+
+    function test_unreached_threshold() public {
+        bytes4 fn = litePsm.fill.selector;
+        bytes memory args = abi.encode(fn);
+        vm.expectRevert(abi.encodeWithSelector(LitePsmJob.UnsupportedFunctionOrThresholdNotReached.selector, fn));
         litePsmJob.work(NET_A, args);
     }
 

--- a/src/tests/LitePsmJob-integration.t.sol
+++ b/src/tests/LitePsmJob-integration.t.sol
@@ -174,14 +174,28 @@ contract LitePsmJobIntegrationTest is DssCronBaseTest {
     function test_unsupported_function() public {
         bytes4 fn = 0x00000000;
         bytes memory args = abi.encode(fn);
-        vm.expectRevert(abi.encodeWithSelector(LitePsmJob.UnsupportedFunctionOrThresholdNotReached.selector, fn));
+        vm.expectRevert(abi.encodeWithSelector(LitePsmJob.UnsupportedFunction.selector, fn));
         litePsmJob.work(NET_A, args);
     }
 
-    function test_unreached_threshold() public {
+    function test_unreached_threshold_fill() public {
         bytes4 fn = litePsm.fill.selector;
         bytes memory args = abi.encode(fn);
-        vm.expectRevert(abi.encodeWithSelector(LitePsmJob.UnsupportedFunctionOrThresholdNotReached.selector, fn));
+        vm.expectRevert(abi.encodeWithSelector(LitePsmJob.ThresholdNotReached.selector, fn));
+        litePsmJob.work(NET_A, args);
+    }
+
+    function test_unreached_threshold_chug() public {
+        bytes4 fn = litePsm.chug.selector;
+        bytes memory args = abi.encode(fn);
+        vm.expectRevert(abi.encodeWithSelector(LitePsmJob.ThresholdNotReached.selector, fn));
+        litePsmJob.work(NET_A, args);
+    }
+
+    function test_unreached_threshold_trim() public {
+        bytes4 fn = litePsm.trim.selector;
+        bytes memory args = abi.encode(fn);
+        vm.expectRevert(abi.encodeWithSelector(LitePsmJob.ThresholdNotReached.selector, fn));
         litePsmJob.work(NET_A, args);
     }
 


### PR DESCRIPTION
This PR fixes the the problem of providing the wrong error message when  `work()` fails due to unreached threshold. Now the error message also includes `ThresholdNotReached`  making it more general to include both revert cases. This was preferred instead of adding many more custom errors for each sub-case. There is also the option of including the current value (< threshold) but it wont give much info and ti will make the error more complex.