### PR TITLE
Check any class in ClipperMomJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Sequencer: [0x238b4E35dAed6100C6162fAE4510261f88996EC9](https://etherscan.io/add
 AutoLineJob [thi=1000 bps, tlo=5000 bps]: [0x67AD4000e73579B9725eE3A149F85C4Af0A61361](https://etherscan.io/address/0x67AD4000e73579B9725eE3A149F85C4Af0A61361#code)  
 LerpJob [maxDuration=1 day]: [0x8F8f2FC1F0380B9Ff4fE5c3142d0811aC89E32fB](https://etherscan.io/address/0x8F8f2FC1F0380B9Ff4fE5c3142d0811aC89E32fB#code)  
 D3MJob [threshold=500 bps, ttl=10 minutes]: [0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF](https://etherscan.io/address/0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF#code)  
-ClipperMomJob: [0xc3A76B34CFBdA7A3a5215629a0B937CBDEC7C71a](https://etherscan.io/address/0xc3A76B34CFBdA7A3a5215629a0B937CBDEC7C71a#code)  
+ClipperMomJob: [0x7E93C4f61C8E8874e7366cDbfeFF934Ed089f9fF](https://etherscan.io/address/0x7E93C4f61C8E8874e7366cDbfeFF934Ed089f9fF#code)
 OracleJob: [0xe717Ec34b2707fc8c226b34be5eae8482d06ED03](https://etherscan.io/address/0xe717Ec34b2707fc8c226b34be5eae8482d06ED03#code)  
 FlapJob [maxGasPrice=138 gwei]: [0xc32506E9bB590971671b649d9B8e18CB6260559F](https://etherscan.io/address/0xc32506E9bB590971671b649d9B8e18CB6260559F#code)  
 

--- a/src/ClipperMomJob.sol
+++ b/src/ClipperMomJob.sol
@@ -23,16 +23,7 @@ interface SequencerLike {
 
 interface IlkRegistryLike {
     function list() external view returns (bytes32[] memory);
-    function info(bytes32 ilk) external view returns (
-        string memory name,
-        string memory symbol,
-        uint256 class,
-        uint256 dec,
-        address gem,
-        address pip,
-        address join,
-        address xlip
-    );
+    function xlip(bytes32 ilk) external view returns (address);
 }
 
 interface ClipperMomLike {
@@ -72,8 +63,7 @@ contract ClipperMomJob is IJob {
         
         bytes32[] memory ilks = ilkRegistry.list();
         for (uint256 i = 0; i < ilks.length; i++) {
-            (,, uint256 class,,,,, address clip) = ilkRegistry.info(ilks[i]);
-            if (class != 1) continue;
+            address clip = ilkRegistry.xlip(ilks[i]);
             if (clip == address(0)) continue;
 
             // We cannot retrieve oracle prices (whitelist-only), so we have to just try and run the trip breaker


### PR DESCRIPTION
This is to support ilks that use other class numbers, such as lockstake.