### PR TITLE
Add StarGuard job

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,23 @@ It is important that the `work` function succeeds IF AND ONLY IF the `workable` 
 
 # Deployed Contracts
 
-Sequencer: [0x238b4E35dAed6100C6162fAE4510261f88996EC9](https://etherscan.io/address/0x238b4E35dAed6100C6162fAE4510261f88996EC9#code)  
+- Sequencer: [0x238b4E35dAed6100C6162fAE4510261f88996EC9](https://etherscan.io/address/0x238b4E35dAed6100C6162fAE4510261f88996EC9#code)
 
 ## Active Jobs
 
-AutoLineJob [thi=1000 bps, tlo=5000 bps]: [0x67AD4000e73579B9725eE3A149F85C4Af0A61361](https://etherscan.io/address/0x67AD4000e73579B9725eE3A149F85C4Af0A61361#code)  
-LerpJob [maxDuration=1 day]: [0x8F8f2FC1F0380B9Ff4fE5c3142d0811aC89E32fB](https://etherscan.io/address/0x8F8f2FC1F0380B9Ff4fE5c3142d0811aC89E32fB#code)  
-D3MJob [threshold=500 bps, ttl=10 minutes]: [0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF](https://etherscan.io/address/0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF#code)  
-ClipperMomJob: [0x7E93C4f61C8E8874e7366cDbfeFF934Ed089f9fF](https://etherscan.io/address/0x7E93C4f61C8E8874e7366cDbfeFF934Ed089f9fF#code)
-OracleJob: [0xe717Ec34b2707fc8c226b34be5eae8482d06ED03](https://etherscan.io/address/0xe717Ec34b2707fc8c226b34be5eae8482d06ED03#code)  
-FlapJob [maxGasPrice=138 gwei]: [0xc32506E9bB590971671b649d9B8e18CB6260559F](https://etherscan.io/address/0xc32506E9bB590971671b649d9B8e18CB6260559F#code)  
-StarGuardJob: [0xB18d211fA69422a9A848B790C5B4a3957F7Aa44E](https://etherscan.io/address/0xb18d211fa69422a9a848b790c5b4a3957f7aa44e#code)
+- AutoLineJob [thi=1000 bps, tlo=5000 bps]: [0x67AD4000e73579B9725eE3A149F85C4Af0A61361](https://etherscan.io/address/0x67AD4000e73579B9725eE3A149F85C4Af0A61361#code)
+- LerpJob [maxDuration=1 day]: [0x8F8f2FC1F0380B9Ff4fE5c3142d0811aC89E32fB](https://etherscan.io/address/0x8F8f2FC1F0380B9Ff4fE5c3142d0811aC89E32fB#code)
+- FlapJob [maxGasPrice=138 gwei]: [0xc32506E9bB590971671b649d9B8e18CB6260559F](https://etherscan.io/address/0xc32506E9bB590971671b649d9B8e18CB6260559F#code)
+- D3MJob [threshold=500 bps, ttl=10 minutes]: [0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF](https://etherscan.io/address/0x2Ea4aDE144485895B923466B4521F5ebC03a0AeF#code)
+- ClipperMomJob: [0x7E93C4f61C8E8874e7366cDbfeFF934Ed089f9fF](https://etherscan.io/address/0x7E93C4f61C8E8874e7366cDbfeFF934Ed089f9fF#code)
+- OracleJob: [0xe717Ec34b2707fc8c226b34be5eae8482d06ED03](https://etherscan.io/address/0xe717Ec34b2707fc8c226b34be5eae8482d06ED03#code)
+- LitePsmJob: [0x0C86162ba3E507592fC8282b07cF18c7F902C401](https://etherscan.io/address/0x0C86162ba3E507592fC8282b07cF18c7F902C401#code)
+- VestedRewardsDistributionJob: [0x6464C34A02DD155dd0c630CE233DD6e21C24F9A5](https://etherscan.io/address/0x6464C34A02DD155dd0c630CE233DD6e21C24F9A5#code)
+- StarGuardJob: [0xB18d211fA69422a9A848B790C5B4a3957F7Aa44E](https://etherscan.io/address/0xb18d211fa69422a9a848b790c5b4a3957f7aa44e#code)
+
 
 ## Network Payment Adapters
 
-NetworkPaymentAdapter (Gelato): [0x0B5a34D084b6A5ae4361de033d1e6255623b41eD](https://etherscan.io/address/0x0B5a34D084b6A5ae4361de033d1e6255623b41eD#code)  
-NetworkPaymentAdapter (Keep3r Network): [0xaeFed819b6657B3960A8515863abe0529Dfc444A](https://etherscan.io/address/0xaeFed819b6657B3960A8515863abe0529Dfc444A#code)  
-NetworkPaymentAdapter (Chainlink): [0xfB5e1D841BDA584Af789bDFABe3c6419140EC065](https://etherscan.io/address/0xfB5e1D841BDA584Af789bDFABe3c6419140EC065#code)  
+- NetworkPaymentAdapter (Gelato): [0x0B5a34D084b6A5ae4361de033d1e6255623b41eD](https://etherscan.io/address/0x0B5a34D084b6A5ae4361de033d1e6255623b41eD#code)
+- NetworkPaymentAdapter (Keep3r Network): [0xaeFed819b6657B3960A8515863abe0529Dfc444A](https://etherscan.io/address/0xaeFed819b6657B3960A8515863abe0529Dfc444A#code)
+- NetworkPaymentAdapter (Chainlink): [0xfB5e1D841BDA584Af789bDFABe3c6419140EC065](https://etherscan.io/address/0xfB5e1D841BDA584Af789bDFABe3c6419140EC065#code)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ D3MJob [threshold=500 bps, ttl=10 minutes]: [0x2Ea4aDE144485895B923466B4521F5ebC
 ClipperMomJob: [0x7E93C4f61C8E8874e7366cDbfeFF934Ed089f9fF](https://etherscan.io/address/0x7E93C4f61C8E8874e7366cDbfeFF934Ed089f9fF#code)
 OracleJob: [0xe717Ec34b2707fc8c226b34be5eae8482d06ED03](https://etherscan.io/address/0xe717Ec34b2707fc8c226b34be5eae8482d06ED03#code)  
 FlapJob [maxGasPrice=138 gwei]: [0xc32506E9bB590971671b649d9B8e18CB6260559F](https://etherscan.io/address/0xc32506E9bB590971671b649d9B8e18CB6260559F#code)  
+StarGuardJob: [0xB18d211fA69422a9A848B790C5B4a3957F7Aa44E](https://etherscan.io/address/0xb18d211fa69422a9a848b790c5b4a3957f7aa44e#code)
 
 ## Network Payment Adapters
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,8 @@ libs = ["lib"]
 solc = '0.8.13'
 # Enabling optimizations to improve gas usage.
 optimizer = true
+optimizer_runs = 200
+via_ir = false
 evm_version = "cancun"
 
 fs_permissions = [
@@ -18,4 +20,5 @@ fs_permissions = [
 mainnet = "${ETH_RPC_URL}"
 
 [etherscan]
+mainnet = { key = "${ETHERSCAN_API_KEY}", chain = 1 }
 unknown_chain = { key = "${TENDERLY_ACCESS_KEY}", chain = 314311, url = "${ETH_RPC_URL}/verify/etherscan" }

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,11 +6,12 @@ libs = ["lib"]
 solc = '0.8.13'
 # Enabling optimizations to improve gas usage.
 optimizer = true
+evm_version = "cancun"
 
 fs_permissions = [
     { access = "read", path = "./out/" },
     { access = "read", path = "./script/input/" },
-    { access = "read-write", path = "./script/output/" }
+    { access = "read-write", path = "./script/output/" },
 ]
 
 [rpc_endpoints]

--- a/script/StarGuardJobDeploy.s.sol
+++ b/script/StarGuardJobDeploy.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+import {MCD, DssInstance} from "dss-test/MCD.sol";
+import {ScriptTools} from "dss-test/ScriptTools.sol";
+import {StarGuardJob} from "src/StarGuardJob.sol";
+
+contract StarGuardJobDeploy is Script {
+    using stdJson for string;
+    using ScriptTools for string;
+
+    string constant NAME = "star-guard-job-deploy";
+
+    address constant CHAINLOG = 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
+    DssInstance dss = MCD.loadFromChainlog(CHAINLOG);
+    address sequencer = dss.chainlog.getAddress("CRON_SEQUENCER");
+    address pauseProxy = dss.chainlog.getAddress("MCD_PAUSE_PROXY");
+
+    uint256 privateKey = vm.envUint("PRIVATE_KEY");
+    address deployer = vm.addr(privateKey);
+
+    function run() external {
+        vm.startBroadcast(privateKey);
+
+        address job = address(new StarGuardJob({_sequencer: sequencer}));
+        ScriptTools.switchOwner(job, deployer, pauseProxy);
+
+        vm.stopBroadcast();
+
+        ScriptTools.exportContract(NAME, "StarGuardJob", job);
+        ScriptTools.exportContract(NAME, "sequencer", sequencer);
+    }
+}

--- a/src/StarGuardJob.sol
+++ b/src/StarGuardJob.sol
@@ -91,7 +91,7 @@ contract StarGuardJob is IJob {
      * @notice A StarGuard contract was removed from the job
      * @param starGuard The removed StarGuard contract
      */
-    event Remove(address indexed starGuard);
+    event Rem(address indexed starGuard);
 
     /**
      * @notice Work os executed
@@ -156,9 +156,9 @@ contract StarGuardJob is IJob {
      * @notice Removes the StarGuard contract from the job
      * @param starGuard The StarGuard contract to remove
      */
-    function remove(address starGuard) external auth {
+    function rem(address starGuard) external auth {
         if (!starGuards.remove(starGuard)) revert NotFound(starGuard);
-        emit Remove(starGuard);
+        emit Rem(starGuard);
     }
 
     // --- getters ---

--- a/src/StarGuardJob.sol
+++ b/src/StarGuardJob.sol
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity ^0.8.13;
+
+import {IJob} from "./interfaces/IJob.sol";
+import "./utils/EnumerableSet.sol";
+
+interface SequencerLike {
+    function isMaster(bytes32 network) external view returns (bool);
+}
+
+interface StarGuardLike {
+    function prob() external view returns (bool result);
+    function exec() external returns (address addr);
+}
+
+/// @title Execute Star payloads `plot`ted in StarGuard
+contract StarGuardJob is IJob {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    // --- storage variables ---
+
+    /// @notice Address with admin access to this contract
+    mapping(address => uint256) public wards;
+
+    /// @notice Iterable set of StarGuard contracts added to the job
+    EnumerableSet.AddressSet private starGuards;
+
+    // --- immutables ---
+
+    /// @notice Keeper Network sequencer
+    SequencerLike public immutable sequencer;
+
+    // --- errors ---
+
+    /**
+     * @notice The keeper trying to execute `work` is not the current master
+     * @param network The keeper identifier
+     */
+    error NotMaster(bytes32 network);
+
+    /// @notice No args were provided to `work`.
+    error NoArgs();
+    
+    /// @notice `work` was called too early or no vested amount is available.
+    error NotDue(address dist);
+    
+    /// @notice The distribution contract was was not added to the job.
+    error NotFound(address dist);
+
+    // --- events ---
+
+    /**
+     * @notice `usr` was granted admin access.
+     * @param usr The user address.
+     */
+    event Rely(address indexed usr);
+
+    /**
+     * @notice `usr` admin access was revoked.
+     * @param usr The user address.
+     */
+    event Deny(address indexed usr);
+
+    /**
+     * @notice A StarGuard contract was added to or modified in the job
+     * @param starGuard The StarGuard contract
+     */
+    event Set(address indexed starGuard);
+
+    /**
+     * @notice A StarGuard contract was removed from the job
+     * @param starGuard The removed StarGuard contract
+     */
+    event Rem(address indexed starGuard);
+
+    /**
+     * @notice Work os executed for a distribution contract
+     * @param network The keeper who executed the job
+     * @param starGuard The distribution contract where the distribution was made
+     * @param starSpell The star payload address
+     */
+    event Work(bytes32 indexed network, address indexed starGuard, address starSpell);
+
+    // --- modifiers ---
+
+    /**
+     * @notice Check if sender is authorized
+     */
+    modifier auth() {
+        require(wards[msg.sender] == 1, "StarGuardJob/not-authorized");
+        _;
+    }
+
+    // --- constructor ---
+
+    /**
+     * @param _sequencer The keeper network sequencer.
+     */
+    constructor(address _sequencer) {
+        sequencer = SequencerLike(_sequencer);
+
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+    }
+
+    // --- administration ---
+
+    /**
+     * @notice Grants `usr` admin access to this contract
+     * @param usr The user address
+     */
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+
+    /**
+     * @notice Revokes `usr` admin access from this contract
+     * @param usr The user address
+     */
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    /**
+     * @notice Sets the StarGuard contract in the job
+     * @param starGuard The StarGuard contract to add
+     */
+    function set(address starGuard) external auth {
+        if (!starGuards.contains(starGuard)) starGuards.add(starGuard);
+        emit Set(starGuard);
+    }
+
+    /**
+     * @notice Removes the StarGuard contract from the job
+     * @param starGuard The StarGuard contract to remove
+     */
+    function rem(address starGuard) external auth {
+        if (!starGuards.remove(starGuard)) revert NotFound(starGuard);
+        emit Rem(starGuard);
+    }
+
+    // --- getters ---
+
+    /**
+     * @notice Checks if the job has the specified StarGuard contract
+     * @param starGuard The StarGuard contract
+     * @return Whether the StarGuard is already there
+     */
+    function has(address starGuard) public view returns (bool) {
+        return starGuards.contains(starGuard);
+    }
+
+    // --- keeper network interface ---
+
+    /**
+     * @notice Executes the job though the keeper network.
+     * @param network The keeper identifier.
+     * @param args The arguments for execution.
+     */
+    function work(bytes32 network, bytes calldata args) external {
+        if (!sequencer.isMaster(network)) revert NotMaster(network);
+        if (args.length == 0) revert NoArgs();
+
+        (address starGuard) = abi.decode(args, (address));
+        // Ensures starGuard was not removed in the meantime
+        if (!has(starGuard)) revert NotFound(starGuard);
+
+        address spell = StarGuardLike(starGuard).exec();
+        emit Work(network, starGuard, spell);
+    }
+
+    /**
+     * @notice Checks if there is work to be done in the job.
+     * @dev Most providers define a gas limit for `eth_call` requests to prevent DoS.
+     *      Notice that hitting that limit is higly unlikely, as it would require hundreds or thousands of active
+     *      contracts in this job.
+     *      Keepers are expected to take that into consideration, especially if they are using self-hosted
+     *      infrastructure, which might have arbitrary values configured.
+     * @param network The keeper identifier.
+     * @return ok Whether it should execute or not.
+     * @return args The args for execution.
+     */
+    function workable(bytes32 network) external override returns (bool ok, bytes memory args) {
+        if (!sequencer.isMaster(network)) return (false, bytes("Network is not master"));
+
+        uint256 len = starGuards.length();
+        for (uint256 i = 0; i < len; i++) {
+            address starGuard = starGuards.at(i);
+            if (!StarGuardLike(starGuard).prob()) continue;
+
+            try this.work(network, abi.encode(starGuard)) {
+                return (true, abi.encode(starGuard));
+            } catch {
+                continue;
+            }
+        }
+        return (false, bytes("No distribution"));
+    }
+}

--- a/src/StarGuardJob.sol
+++ b/src/StarGuardJob.sol
@@ -158,9 +158,17 @@ contract StarGuardJob is IJob {
     // --- getters ---
 
     /**
+     * @notice Output the amount of active starGuards
+     * @return length The amount of active starGuards
+     */
+    function length() public view returns (uint256) {
+        return starGuards.length();
+    }
+
+    /**
      * @notice Checks if the job has the specified StarGuard contract
      * @param starGuard The StarGuard contract
-     * @return Whether the StarGuard is already there
+     * @return Whether The StarGuard is already there
      */
     function has(address starGuard) public view returns (bool) {
         return starGuards.contains(starGuard);

--- a/src/StarGuardJob.sol
+++ b/src/StarGuardJob.sol
@@ -56,10 +56,16 @@ contract StarGuardJob is IJob {
     error NoArgs();
 
     /**
-     * @notice The distribution contract was was not added to the job.
+     * @notice The StarGuard contract was not added to the job.
      * @param starGuard The StarGuard contract
      */
     error NotFound(address starGuard);
+
+    /**
+     * @notice The StarGuard contract was already added to the job.
+     * @param starGuard The StarGuard contract
+     */
+    error AlreadyAdded(address starGuard);
 
     // --- events ---
 
@@ -88,10 +94,10 @@ contract StarGuardJob is IJob {
     event Remove(address indexed starGuard);
 
     /**
-     * @notice Work os executed for a distribution contract
+     * @notice Work os executed
      * @param network The keeper who executed the job
-     * @param starGuard The distribution contract where the distribution was made
-     * @param starSpell The star payload address
+     * @param starGuard The StarGuard which executed the payload
+     * @param starSpell The payload address
      */
     event Work(bytes32 indexed network, address indexed starGuard, address starSpell);
 
@@ -142,7 +148,7 @@ contract StarGuardJob is IJob {
      * @param starGuard The StarGuard contract to add
      */
     function add(address starGuard) external auth {
-        if (!starGuards.contains(starGuard)) starGuards.add(starGuard);
+        if (!starGuards.add(starGuard)) revert AlreadyAdded(starGuard);
         emit Add(starGuard);
     }
 
@@ -218,6 +224,6 @@ contract StarGuardJob is IJob {
                 continue;
             }
         }
-        return (false, bytes("No distribution"));
+        return (false, bytes("No spells to execute"));
     }
 }

--- a/src/StarGuardJob.sol
+++ b/src/StarGuardJob.sol
@@ -79,13 +79,13 @@ contract StarGuardJob is IJob {
      * @notice A StarGuard contract was added to or modified in the job
      * @param starGuard The StarGuard contract
      */
-    event Set(address indexed starGuard);
+    event Add(address indexed starGuard);
 
     /**
      * @notice A StarGuard contract was removed from the job
      * @param starGuard The removed StarGuard contract
      */
-    event Rem(address indexed starGuard);
+    event Remove(address indexed starGuard);
 
     /**
      * @notice Work os executed for a distribution contract
@@ -138,21 +138,21 @@ contract StarGuardJob is IJob {
     }
 
     /**
-     * @notice Sets the StarGuard contract in the job
+     * @notice Adds the StarGuard contract in the job
      * @param starGuard The StarGuard contract to add
      */
-    function set(address starGuard) external auth {
+    function add(address starGuard) external auth {
         if (!starGuards.contains(starGuard)) starGuards.add(starGuard);
-        emit Set(starGuard);
+        emit Add(starGuard);
     }
 
     /**
      * @notice Removes the StarGuard contract from the job
      * @param starGuard The StarGuard contract to remove
      */
-    function rem(address starGuard) external auth {
+    function remove(address starGuard) external auth {
         if (!starGuards.remove(starGuard)) revert NotFound(starGuard);
-        emit Rem(starGuard);
+        emit Remove(starGuard);
     }
 
     // --- getters ---

--- a/src/StarGuardJob.sol
+++ b/src/StarGuardJob.sol
@@ -216,8 +216,6 @@ contract StarGuardJob is IJob {
         uint256 len = starGuards.length();
         for (uint256 i = 0; i < len; i++) {
             address starGuard = starGuards.at(i);
-            if (!StarGuardLike(starGuard).prob()) continue;
-
             try this.work(network, abi.encode(starGuard)) {
                 return (true, abi.encode(starGuard));
             } catch {

--- a/src/StarGuardJob.sol
+++ b/src/StarGuardJob.sol
@@ -54,12 +54,12 @@ contract StarGuardJob is IJob {
 
     /// @notice No args were provided to `work`.
     error NoArgs();
-    
-    /// @notice `work` was called too early or no vested amount is available.
-    error NotDue(address dist);
-    
-    /// @notice The distribution contract was was not added to the job.
-    error NotFound(address dist);
+
+    /**
+     * @notice The distribution contract was was not added to the job.
+     * @param starGuard The StarGuard contract
+     */
+    error NotFound(address starGuard);
 
     // --- events ---
 

--- a/src/tests/StarGuardJobIntegration.t.sol
+++ b/src/tests/StarGuardJobIntegration.t.sol
@@ -122,6 +122,16 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
         checkAuth(address(job), "StarGuardJob");
     }
 
+    function testAuthModifiers() public {
+        bytes4[] memory authedMethods = new bytes4[](2);
+        authedMethods[0] = StarGuardJob.add.selector;
+        authedMethods[1] = StarGuardJob.remove.selector;
+
+        vm.startPrank(unauthedUser);
+        checkModifier(address(job), "StarGuardJob/not-authorized", authedMethods);
+        vm.stopPrank();
+    }
+
     function testAdd() public {
         assertEq(job.length(), 0);
         assertFalse(job.has(starGuardSpark));
@@ -130,12 +140,6 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
         job.add(starGuardSpark);
         assertTrue(job.has(starGuardSpark));
         assertEq(job.length(), 1);
-    }
-
-    function testAddNoAuth() public {
-        vm.prank(unauthedUser);
-        vm.expectRevert("StarGuardJob/not-authorized");
-        job.add(starGuardSpark);
     }
 
     function testAddDuplicate() public {
@@ -153,13 +157,6 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
         job.remove(starGuardSpark);
         assertFalse(job.has(starGuardSpark));
         assertEq(job.length(), 0);
-    }
-
-    function testRemoveNoAuth() public {
-        job.add(starGuardSpark);
-        vm.prank(unauthedUser);
-        vm.expectRevert("StarGuardJob/not-authorized");
-        job.remove(starGuardSpark);
     }
 
     function testRemoveNotFound() public {

--- a/src/tests/StarGuardJobIntegration.t.sol
+++ b/src/tests/StarGuardJobIntegration.t.sol
@@ -102,7 +102,7 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
 
     // --- Events ---
     event Add(address indexed starGuard);
-    event Remove(address indexed starGuard);
+    event Rem(address indexed starGuard);
     event Work(bytes32 indexed network, address indexed starGuard, address starSpell);
 
     function setUpSub() internal virtual override {
@@ -125,7 +125,7 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
     function testAuthModifiers() public {
         bytes4[] memory authedMethods = new bytes4[](2);
         authedMethods[0] = StarGuardJob.add.selector;
-        authedMethods[1] = StarGuardJob.remove.selector;
+        authedMethods[1] = StarGuardJob.rem.selector;
 
         vm.startPrank(unauthedUser);
         checkModifier(address(job), "StarGuardJob/not-authorized", authedMethods);
@@ -153,15 +153,15 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
     function testRemove() public {
         job.add(starGuardSpark);
         vm.expectEmit(true, true, true, true);
-        emit Remove(starGuardSpark);
-        job.remove(starGuardSpark);
+        emit Rem(starGuardSpark);
+        job.rem(starGuardSpark);
         assertFalse(job.has(starGuardSpark));
         assertEq(job.length(), 0);
     }
 
     function testRemoveNotFound() public {
         vm.expectRevert(abi.encodeWithSelector(StarGuardJob.NotFound.selector, starGuardSpark));
-        job.remove(starGuardSpark);
+        job.rem(starGuardSpark);
     }
 
     function testWork() public {

--- a/src/tests/StarGuardJobIntegration.t.sol
+++ b/src/tests/StarGuardJobIntegration.t.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "./DssCronBase.t.sol";
+
+import {StarGuardJob} from "../StarGuardJob.sol";
+
+interface StarGuardLike {
+    function exec() external returns (address addr);
+    function file(bytes32 what, uint256 data) external;
+    function maxDelay() external view returns (uint256 maxDelay);
+    function plot(address addr_, bytes32 tag_) external;
+    function spellData() external view returns (address addr, bytes32 tag, uint256 deadline);
+    function subProxy() external view returns (address subProxy);
+}
+
+interface SubProxyLike {
+    function rely(address usr) external;
+}
+
+contract StandardStarSpell {
+    function isExecutable() external pure returns (bool) {
+        return true;
+    }
+
+    function execute() external {}
+}
+
+contract DelayedStarSpell {
+    uint256 internal immutable executableAt;
+
+    constructor(uint256 executableAt_) {
+        executableAt = executableAt_;
+    }
+
+    function isExecutable() external view returns (bool) {
+        return block.timestamp >= executableAt;
+    }
+
+    function execute() external {}
+}
+
+contract StarGuardJobIntegrationTest is DssCronBaseTest {
+    using stdStorage for StdStorage;
+
+    address internal constant unauthedUser = address(0xB0B);
+    address internal constant starGuardSpark = address(0x35bb93c01C425Ba940C298E372E1D2ad6df2CA87);
+
+    StarGuardJob public job;
+    address public pauseProxy;
+
+    // --- Events ---
+    event Set(address indexed starGuard);
+    event Rem(address indexed starGuard);
+    event Work(bytes32 indexed network, address indexed starGuard, address starSpell);
+
+    function setUpSub() internal virtual override {
+        job = new StarGuardJob(address(sequencer));
+        pauseProxy = dss.chainlog.getAddress("MCD_PAUSE_PROXY");
+
+        // Init starGuardSpark
+        address subProxy = StarGuardLike(starGuardSpark).subProxy();
+        vm.prank(pauseProxy);
+        SubProxyLike(subProxy).rely(starGuardSpark);
+    }
+
+    function testAuth() public {
+        checkAuth(address(job), "StarGuardJob");
+    }
+
+    function testSet() public {
+        assertEq(job.length(), 0);
+        assertFalse(job.has(starGuardSpark));
+        vm.expectEmit(true, true, true, true);
+        emit Set(starGuardSpark);
+        job.set(starGuardSpark);
+        assertTrue(job.has(starGuardSpark));
+        assertEq(job.length(), 1);
+    }
+
+    function testSetNoAuth() public {
+        vm.prank(unauthedUser);
+        vm.expectRevert("StarGuardJob/not-authorized");
+        job.set(starGuardSpark);
+    }
+
+    function testSetDuplicate() public {
+        job.set(starGuardSpark);
+        assertTrue(job.has(starGuardSpark));
+        job.set(starGuardSpark);
+        assertTrue(job.has(starGuardSpark));
+        assertEq(job.length(), 1);
+    }
+
+    function testRem() public {
+        job.set(starGuardSpark);
+        vm.expectEmit(true, true, true, true);
+        emit Rem(starGuardSpark);
+        job.rem(starGuardSpark);
+        assertFalse(job.has(starGuardSpark));
+        assertEq(job.length(), 0);
+    }
+
+    function testRemNoAuth() public {
+        job.set(starGuardSpark);
+        vm.prank(unauthedUser);
+        vm.expectRevert("StarGuardJob/not-authorized");
+        job.rem(starGuardSpark);
+    }
+
+    function testRemNotFound() public {
+        vm.expectRevert(abi.encodeWithSelector(StarGuardJob.NotFound.selector, starGuardSpark));
+        job.rem(starGuardSpark);
+    }
+
+    function testWork() public {
+        // Prepare job
+        job.set(starGuardSpark);
+
+        // Prepare StarGuard
+        address spell = address(new StandardStarSpell());
+        vm.prank(pauseProxy);
+        StarGuardLike(starGuardSpark).plot(spell, spell.codehash);
+
+        // Check workable state
+        uint256 beforeWorkable = vm.snapshot();
+        (bool canWork, bytes memory args) = job.workable(NET_A);
+        assertTrue(canWork, "unexpected workable() false with spell");
+        (address starGuard) = abi.decode(args, (address));
+        assertEq(starGuard, starGuardSpark, "unexpected starGuard address");
+
+        // Work
+        vm.revertTo(beforeWorkable); // snapshot is required as `workable` modifies state
+        vm.expectEmit(true, true, true, true);
+        emit Work(NET_A, starGuardSpark, spell);
+        job.work(NET_A, args);
+        (address addr,,) = StarGuardLike(starGuardSpark).spellData();
+        assertEq(addr, address(0), "unexpected starGuard spell after execution");
+    }
+
+    function testWorkWithoutSpell() public {
+        job.set(starGuardSpark);
+        (bool canWork, bytes memory args) = job.workable(NET_A);
+        assertFalse(canWork, "unexpected workable() true with no spell");
+        assertEq(args, "No distribution", "unexpected calldata with no spell");
+    }
+
+    function testWorkWithDelayedSpell() public {
+        // Prepare job
+        job.set(starGuardSpark);
+
+        // Prepare delayed spell
+        uint256 executableAt = block.timestamp + 1 days;
+        address delayedStarSpell = address(new DelayedStarSpell(executableAt));
+
+        // Prepare StarGuard
+        vm.startPrank(pauseProxy);
+        StarGuardLike(starGuardSpark).file("maxDelay", type(uint160).max);
+        StarGuardLike(starGuardSpark).plot(delayedStarSpell, delayedStarSpell.codehash);
+        vm.stopPrank();
+
+        // Check workable state immidiately
+        {
+            (bool canWork,) = job.workable(NET_A);
+            assertFalse(canWork, "unexpected workable() true with delayed spell: immidiate");
+        }
+
+        // Check workable state at executableAt - 1
+        {
+            vm.warp(executableAt - 1);
+            (bool canWork,) = job.workable(NET_A);
+            assertFalse(canWork, "unexpected workable() true with delayed spell: almost at executable");
+        }
+
+        // Check workable state at executableAt
+        vm.warp(executableAt);
+        uint256 beforeWorkable = vm.snapshot();
+        (bool canWork, bytes memory args) = job.workable(NET_A);
+        assertTrue(canWork, "unexpected workable() false with delayed spell: at executable");
+
+        // Work
+        vm.revertTo(beforeWorkable); // snapshot is required as `workable` modifies state
+        job.work(NET_A, args);
+    }
+}

--- a/src/tests/StarGuardJobIntegration.t.sol
+++ b/src/tests/StarGuardJobIntegration.t.sol
@@ -141,8 +141,8 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
     function testAddDuplicate() public {
         job.add(starGuardSpark);
         assertTrue(job.has(starGuardSpark));
+        vm.expectRevert(abi.encodeWithSelector(StarGuardJob.AlreadyAdded.selector, starGuardSpark));
         job.add(starGuardSpark);
-        assertTrue(job.has(starGuardSpark));
         assertEq(job.length(), 1);
     }
 
@@ -217,7 +217,7 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
         job.add(starGuardSpark);
         (bool canWork, bytes memory args) = job.workable(NET_A);
         assertFalse(canWork, "unexpected workable() true with no spell");
-        assertEq(args, "No distribution", "unexpected calldata with no spell");
+        assertEq(args, "No spells to execute", "unexpected calldata with no spell");
     }
 
     function testWorkWithDelayedSpell() public {

--- a/src/tests/StarGuardJobIntegration.t.sol
+++ b/src/tests/StarGuardJobIntegration.t.sol
@@ -231,10 +231,10 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
         StarGuardLike(starGuardSpark).plot(delayedStarSpell, delayedStarSpell.codehash);
         vm.stopPrank();
 
-        // Check state immidiately
+        // Check state immediately
         {
             (bool canWork,) = job.workable(NET_A);
-            assertFalse(canWork, "unexpected workable() true with delayed spell: immidiate");
+            assertFalse(canWork, "unexpected workable() true with delayed spell: immediate");
         }
 
         // Check state at executableAt - 1
@@ -273,7 +273,7 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
 
         // Check workable state
         (bool canWork,) = job.workable(NET_A);
-        assertFalse(canWork, "unexpected workable() true with malicious spell");
+        assertFalse(canWork, "unexpected workable() true with invalid spell");
     }
 
     function testWorkableWithMaliciousSpell() public {

--- a/src/tests/StarGuardJobIntegration.t.sol
+++ b/src/tests/StarGuardJobIntegration.t.sol
@@ -101,8 +101,8 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
     address public pauseProxy;
 
     // --- Events ---
-    event Set(address indexed starGuard);
-    event Rem(address indexed starGuard);
+    event Add(address indexed starGuard);
+    event Remove(address indexed starGuard);
     event Work(bytes32 indexed network, address indexed starGuard, address starSpell);
 
     function setUpSub() internal virtual override {
@@ -122,55 +122,55 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
         checkAuth(address(job), "StarGuardJob");
     }
 
-    function testSet() public {
+    function testAdd() public {
         assertEq(job.length(), 0);
         assertFalse(job.has(starGuardSpark));
         vm.expectEmit(true, true, true, true);
-        emit Set(starGuardSpark);
-        job.set(starGuardSpark);
+        emit Add(starGuardSpark);
+        job.add(starGuardSpark);
         assertTrue(job.has(starGuardSpark));
         assertEq(job.length(), 1);
     }
 
-    function testSetNoAuth() public {
+    function testAddNoAuth() public {
         vm.prank(unauthedUser);
         vm.expectRevert("StarGuardJob/not-authorized");
-        job.set(starGuardSpark);
+        job.add(starGuardSpark);
     }
 
-    function testSetDuplicate() public {
-        job.set(starGuardSpark);
+    function testAddDuplicate() public {
+        job.add(starGuardSpark);
         assertTrue(job.has(starGuardSpark));
-        job.set(starGuardSpark);
+        job.add(starGuardSpark);
         assertTrue(job.has(starGuardSpark));
         assertEq(job.length(), 1);
     }
 
-    function testRem() public {
-        job.set(starGuardSpark);
+    function testRemove() public {
+        job.add(starGuardSpark);
         vm.expectEmit(true, true, true, true);
-        emit Rem(starGuardSpark);
-        job.rem(starGuardSpark);
+        emit Remove(starGuardSpark);
+        job.remove(starGuardSpark);
         assertFalse(job.has(starGuardSpark));
         assertEq(job.length(), 0);
     }
 
-    function testRemNoAuth() public {
-        job.set(starGuardSpark);
+    function testRemoveNoAuth() public {
+        job.add(starGuardSpark);
         vm.prank(unauthedUser);
         vm.expectRevert("StarGuardJob/not-authorized");
-        job.rem(starGuardSpark);
+        job.remove(starGuardSpark);
     }
 
-    function testRemNotFound() public {
+    function testRemoveNotFound() public {
         vm.expectRevert(abi.encodeWithSelector(StarGuardJob.NotFound.selector, starGuardSpark));
-        job.rem(starGuardSpark);
+        job.remove(starGuardSpark);
     }
 
     function testWork() public {
         // Prepare jobs
-        job.set(starGuardSpark);
-        job.set(starGuardGrove);
+        job.add(starGuardSpark);
+        job.add(starGuardGrove);
 
         // Plot both spells
         address spellSpark = address(new StandardStarSpell());
@@ -214,7 +214,7 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
     }
 
     function testWorkWithoutSpell() public {
-        job.set(starGuardSpark);
+        job.add(starGuardSpark);
         (bool canWork, bytes memory args) = job.workable(NET_A);
         assertFalse(canWork, "unexpected workable() true with no spell");
         assertEq(args, "No distribution", "unexpected calldata with no spell");
@@ -222,7 +222,7 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
 
     function testWorkWithDelayedSpell() public {
         // Prepare job
-        job.set(starGuardSpark);
+        job.add(starGuardSpark);
 
         // Prepare delayed spell
         uint256 executableAt = block.timestamp + 1 days;
@@ -262,7 +262,7 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
 
     function testWorkableWithInvalidSpell() public {
         // Prepare job
-        job.set(starGuardSpark);
+        job.add(starGuardSpark);
 
         // Prepare malicious spell
         address maliciousStarSpell = address(new InvalidStarSpell());
@@ -281,7 +281,7 @@ contract StarGuardJobIntegrationTest is DssCronBaseTest {
 
     function testWorkableWithMaliciousSpell() public {
         // Prepare job
-        job.set(starGuardSpark);
+        job.add(starGuardSpark);
 
         // Prepare malicious spell
         address maliciousStarSpell = address(new MaliciousStarSpell(starGuardSpark));


### PR DESCRIPTION
This PR implements new `StarGuardJob` job contract and its tests. The job suppose to check all added [StarGuard modules](https://github.com/sidestream-tech/sky-star-guard/) in the loop and automatically execute spells plotted in them.

The new contract can be tested via `forge test --rpc-url mainnet src/tests/StarGuardJobIntegration.t.sol -vvv`